### PR TITLE
Remove comments from SQL files

### DIFF
--- a/Datawarehouse/ALL_Dim_Initial_ETL.sql
+++ b/Datawarehouse/ALL_Dim_Initial_ETL.sql
@@ -3,7 +3,7 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
-    -- List of all Initial Dimension ETL procedures
+
     DECLARE @procs TABLE (ProcName NVARCHAR(128));
     INSERT INTO @procs (ProcName) VALUES
         (N'Initial_Date_Dim'),
@@ -30,7 +30,7 @@ BEGIN
     FETCH NEXT FROM proc_cursor INTO @ProcName;
     WHILE @@FETCH_STATUS = 0
     BEGIN
-        -- Check existence with correct schema and proc name, and run
+
         IF OBJECT_ID(N'DW.' + @ProcName, 'P') IS NOT NULL
         BEGIN
             SET @sql = N'EXEC [DW].[' + @ProcName + N']';
@@ -47,6 +47,6 @@ BEGIN
 END
 GO
 
--- Example: Run all dimension initial ETLs
+
 EXEC [DW].[Main_Dim_Initial_ETL];
 GO

--- a/Datawarehouse/ALL_Fact_Initial_ETL.sql
+++ b/Datawarehouse/ALL_Fact_Initial_ETL.sql
@@ -14,11 +14,11 @@ EXEC [DW].[Initial_PersonPointTransactions_MonthlyFact];
 GO
 EXEC [DW].[Initial_PersonPointTransactions_ACCFact];
 GO
--- EXEC [DW].[Initial_AircraftHealth_MonthlyFact];
+
 GO
 EXEC [DW].[Initial_MaintenanceEvent_TransactionalFact];
 GO
--- EXEC [DW].[Initial_PartReplacement_TransactionalFact];
+
 GO
 EXEC [DW].[Initial_FlightPerformance_TransactionalFact];
 GO

--- a/Datawarehouse/ALL_Load.sql
+++ b/Datawarehouse/ALL_Load.sql
@@ -3,7 +3,7 @@ AS
 BEGIN
 SET NOCOUNT ON;
 
--- ====== DIMENSION ETL ======
+
     EXEC [DW].[ETL_Account_Dim];
     EXEC [DW].[ETL_Aircraft_Dim];
     EXEC [DW].[ETL_AirlineAirportService_Dim];
@@ -18,24 +18,24 @@ SET NOCOUNT ON;
     EXEC [DW].[ETL_PointConversionRate_Dim];
     EXEC [DW].[ETL_ServiceOffering_Dim];
     EXEC [DW].[ETL_TravelClass_Dim];
-    -- EXEC [DW].[ETL_Technician_Dim];
-    -- EXEC [DW].[ETL_MaintenanceLocation_Dim];
-    -- EXEC [DW].[ETL_MaintenanceType_Dim];
-    -- EXEC [DW].[ETL_Part_Dim];
 
-    -- ====== FACT ETL ======
 
-    -- LoyaltyMart
+
+
+
+
+
+
     EXEC [DW].[Load_LoyaltyPoint_TransactionalFact];
     EXEC [DW].[Load_CrewAssignmentEvent_Factless];
     EXEC [DW].[Load_PersonPointTransactions_MonthlyFact];
     EXEC [DW].[Load_PersonPointTransactions_ACCFact];
-    -- RevenueMart
+
     EXEC [DW].[Load_FlightOperation_Factless];
     EXEC [DW].[Load_PassengerActivity_ACCFact];
     EXEC [DW].[Load_PassengerTicket_TransactionalFact];
     EXEC [DW].[Load_PassengerActivity_YearlyFact];
-    -- PerformanceMart
+
     EXEC [DW].[Load_FlightPerformance_TransactionalFact];
     EXEC [DW].[Load_FlightPerformance_DailyFact];
     EXEC [DW].[Load_FlightPerformance_ACCFact];

--- a/Datawarehouse/Create_Log_Table.sql
+++ b/Datawarehouse/Create_Log_Table.sql
@@ -1,13 +1,13 @@
 CREATE TABLE [DW].[ETL_Log] (
   [LogID]             BIGINT            IDENTITY(1,1) NOT NULL PRIMARY KEY,
-  [ProcedureName]     NVARCHAR(255)     NOT NULL,         -- e.g. 'usp_LoadDimPerson_Initial'
-  [TargetTable]       NVARCHAR(255)     NOT NULL,         -- e.g. 'DimPerson'
-  [ChangeDescription] NVARCHAR(MAX)     NULL,             -- free-form description of what the proc did
-  [RowsAffected]      INT               NULL,             -- number of rows inserted/updated/deleted
-  [ActionTime]        DATETIME2(3)      NOT NULL  
-    DEFAULT SYSUTCDATETIME(),                            -- when the action occurred
-  [DurationSec]       DECIMAL(9,3)      NULL,             -- elapsed time in seconds
-  [Status]            NVARCHAR(50)      NULL,             -- e.g. 'Success', 'Error'
-  [Message]           NVARCHAR(MAX)     NULL              -- any error or informational message
+  [ProcedureName]     NVARCHAR(255)     NOT NULL,
+  [TargetTable]       NVARCHAR(255)     NOT NULL,
+  [ChangeDescription] NVARCHAR(MAX)     NULL,
+  [RowsAffected]      INT               NULL,
+  [ActionTime]        DATETIME2(3)      NOT NULL
+    DEFAULT SYSUTCDATETIME(),
+  [DurationSec]       DECIMAL(9,3)      NULL,
+  [Status]            NVARCHAR(50)      NULL,
+  [Message]           NVARCHAR(MAX)     NULL
 );
 GO

--- a/Datawarehouse/Create_Temp_Tables.sql
+++ b/Datawarehouse/Create_Temp_Tables.sql
@@ -297,7 +297,7 @@ GO
 IF OBJECT_ID('[DW].[Temp_EnrichedLoyaltyData]', 'U') IS NULL
 BEGIN
 CREATE TABLE [DW].[Temp_EnrichedLoyaltyData](
-    -- Dimension Keys
+
 	[TransactionDateKey] [datetime] NOT NULL,
 	[PersonKey] [int] NOT NULL,
 	[AccountKey] [int] NOT NULL,
@@ -306,7 +306,7 @@ CREATE TABLE [DW].[Temp_EnrichedLoyaltyData](
 	[ConversionRateKey] [int] NULL,
 	[FlightKey] [int] NULL,
 	[ServiceOfferingKey] [int] NULL,
-    -- Measures
+
 	[PointsChange] [decimal](18, 2) NOT NULL,
 	[CurrencyValue] [decimal](18, 2) NULL,
 	[ConversionRateSnapshot] [decimal](18, 6) NULL,

--- a/Datawarehouse/Dimensions/Create_Account_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_Account_Dim.sql
@@ -1,8 +1,8 @@
 CREATE TABLE [DW].[DimAccount] (
-  [AccountID] INT PRIMARY KEY,           
-  [PassengerName] NVARCHAR(100),         
-  [RegistrationDate] DATETIME,           
-  [LoyaltyTierName] NVARCHAR(50)         
+  [AccountID] INT PRIMARY KEY,
+  [PassengerName] NVARCHAR(100),
+  [RegistrationDate] DATETIME,
+  [LoyaltyTierName] NVARCHAR(50)
 )
 GO
 

--- a/Datawarehouse/Dimensions/Create_Airline_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_Airline_Dim.sql
@@ -1,13 +1,13 @@
 CREATE TABLE [DW].[DimAirline] (
-  [AirlineID] INT PRIMARY KEY,             
+  [AirlineID] INT PRIMARY KEY,
   [Name] NVARCHAR(100),
   [Country] NVARCHAR(50),
   [FoundedYear] INT,
   [FleetSize] INT,
   [Website] NVARCHAR(200),
-  [Current_IATA_Code] NVARCHAR(3) NULL,    
-  [Previous_IATA_Code] NVARCHAR(3) NULL,    
-  [IATA_Code_Changed_Date] DATE NULL       
+  [Current_IATA_Code] NVARCHAR(3) NULL,
+  [Previous_IATA_Code] NVARCHAR(3) NULL,
+  [IATA_Code_Changed_Date] DATE NULL
 );
 GO
 

--- a/Datawarehouse/Dimensions/Create_Flight_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_Flight_Dim.sql
@@ -1,11 +1,11 @@
 CREATE TABLE [DW].[DimFlight] (
-  [FlightDetailID]      INT PRIMARY KEY,        
-  [DepartureAirportName] NVARCHAR(100),         
-  [DestinationAirportName] NVARCHAR(100),      
+  [FlightDetailID]      INT PRIMARY KEY,
+  [DepartureAirportName] NVARCHAR(100),
+  [DestinationAirportName] NVARCHAR(100),
   [DepartureDateTime]   DATETIME,
   [ArrivalDateTime]     DATETIME,
   [FlightDurationMinutes] INT,
-  [AircraftName]        NVARCHAR(100),          
+  [AircraftName]        NVARCHAR(100),
   [FlightCapacity]      INT,
   [TotalCost]           DECIMAL(18,2)
 );

--- a/Datawarehouse/Dimensions/Create_LoyaltyTier_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_LoyaltyTier_Dim.sql
@@ -21,5 +21,5 @@ GO
 
 CREATE NONCLUSTERED INDEX IX_DimLoyaltyTier_MinPointsIsCurrent
 ON [DW].[DimLoyaltyTier] (MinPointsIsCurrent)
-WHERE MinPointsIsCurrent = 1; 
+WHERE MinPointsIsCurrent = 1;
 GO

--- a/Datawarehouse/Dimensions/Create_LoyaltyTransactionType_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_LoyaltyTransactionType_Dim.sql
@@ -1,5 +1,5 @@
 CREATE TABLE [DW].[DimLoyaltyTransactionType] (
-  LoyaltyTransactionTypeID INT PRIMARY KEY,   
+  LoyaltyTransactionTypeID INT PRIMARY KEY,
   TypeName NVARCHAR(250)
 );
 GO

--- a/Datawarehouse/Dimensions/Create_Person_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_Person_Dim.sql
@@ -1,5 +1,5 @@
 CREATE TABLE [DW].[DimPerson] (
-  -- Surrogate key for SCD Type 2 versions
+
   [PersonKey]                INT             IDENTITY(1,1) NOT NULL PRIMARY KEY,
   [PersonID]                 INT             NOT NULL,
   [NationalCode]             NVARCHAR(255)   NULL,

--- a/Datawarehouse/Dimensions/Create_PointConversionRate_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_PointConversionRate_Dim.sql
@@ -1,11 +1,11 @@
 CREATE TABLE [DW].[DimPointConversionRate] (
-    ConversionRateKey      INT IDENTITY(1,1) PRIMARY KEY,   -- Surrogate Key
-    PointConversionRateID  INT NOT NULL,                    -- Business Key from SA
+    ConversionRateKey      INT IDENTITY(1,1) PRIMARY KEY,
+    PointConversionRateID  INT NOT NULL,
     Rate                   DECIMAL(18,6),
     Currency               NVARCHAR(255),
     EffectiveFrom          DATETIME NOT NULL,
     EffectiveTo            DATETIME NULL,
-    IsCurrent              BIT 
+    IsCurrent              BIT
 );
 GO
 

--- a/Datawarehouse/Dimensions/Create_ServiceOffering_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_ServiceOffering_Dim.sql
@@ -2,9 +2,9 @@ CREATE TABLE [DW].[DimServiceOffering] (
   [ServiceOfferingID] INT PRIMARY KEY,
   [OfferingName] NVARCHAR(100),
   [Description] NVARCHAR(300),
-  [TravelClassName] NVARCHAR(50),         
+  [TravelClassName] NVARCHAR(50),
   [TotalCost] DECIMAL(18,2),
-  [ItemsSummary] NVARCHAR(400)           
+  [ItemsSummary] NVARCHAR(400)
 );
 GO
 

--- a/Datawarehouse/Dimensions/Create_Technician_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_Technician_Dim.sql
@@ -1,8 +1,8 @@
 CREATE TABLE [DW].[DimTechnician] (
   [Technician_ID] integer PRIMARY KEY,
   [PersonID] INT,
-  [Name] NVARCHAR(100),     
-  [Phone] NVARCHAR(20),     
+  [Name] NVARCHAR(100),
+  [Phone] NVARCHAR(20),
   [Specialty] NVARCHAR(100)
 );
 GO

--- a/Datawarehouse/Dimensions/Create_TravelClass_Dim.sql
+++ b/Datawarehouse/Dimensions/Create_TravelClass_Dim.sql
@@ -1,5 +1,5 @@
 CREATE TABLE [DW].[DimTravelClass] (
-    [TravelClassKey] INT PRIMARY KEY, 
+    [TravelClassKey] INT PRIMARY KEY,
     [ClassName]      NVARCHAR(50) NOT NULL,
     [Capacity]       INT NULL
 );

--- a/Datawarehouse/Dimensions/ETL_AirlineAirportService_Dim.sql
+++ b/Datawarehouse/Dimensions/ETL_AirlineAirportService_Dim.sql
@@ -1,4 +1,4 @@
--- Incremental ETL for DimAirlineAirportService
+
 CREATE OR ALTER PROCEDURE [DW].[ETL_AirlineAirportService_Dim]
 AS
 BEGIN

--- a/Datawarehouse/Dimensions/ETL_Airport_Dim.sql
+++ b/Datawarehouse/Dimensions/ETL_Airport_Dim.sql
@@ -1,4 +1,4 @@
--- Temp table for staging
+
 IF OBJECT_ID('[DW].[Temp_Airport_table]', 'U') IS NULL
 BEGIN
   CREATE TABLE [DW].[Temp_Airport_table] (

--- a/Datawarehouse/Dimensions/ETL_Flight_Dim.sql
+++ b/Datawarehouse/Dimensions/ETL_Flight_Dim.sql
@@ -43,12 +43,12 @@ BEGIN
     )
     SELECT
       f.FlightDetailID,
-      dep.City + ' Airport',         
+      dep.City + ' Airport',
       dest.City + ' Airport',
       f.DepartureDateTime,
       f.ArrivalDateTime,
       DATEDIFF(MINUTE, f.DepartureDateTime, f.ArrivalDateTime),
-      a.Model,                        
+      a.Model,
       f.FlightCapacity,
       f.TotalCost
     FROM SA.FlightDetail AS f

--- a/Datawarehouse/Dimensions/ETL_LoyaltyTier_Dim.sql
+++ b/Datawarehouse/Dimensions/ETL_LoyaltyTier_Dim.sql
@@ -45,7 +45,7 @@ BEGIN
       lt.Benefits
     FROM SA.LoyaltyTier AS lt
     WHERE lt.StagingLastUpdateTimestampUTC > @LastRunTime;
-    
+
     UPDATE d
     SET
       d.EffectiveTo         = @StartTime,

--- a/Datawarehouse/Dimensions/ETL_TravelClass_Dim.sql
+++ b/Datawarehouse/Dimensions/ETL_TravelClass_Dim.sql
@@ -33,38 +33,38 @@ BEGIN
     INSERT INTO DW.Temp_TravelClass_Dim (
       TravelClassID,
       ClassName,
-      Capacity -- ADDED
+      Capacity
     )
     SELECT
       tc.TravelClassID,
       tc.ClassName,
-      tc.Capacity -- ADDED
+      tc.Capacity
     FROM SA.TravelClass AS tc
     WHERE tc.StagingLastUpdateTimestampUTC > @LastRunTime;
 
     UPDATE d
     SET
       d.ClassName = t.ClassName,
-      d.Capacity  = t.Capacity -- ADDED
+      d.Capacity  = t.Capacity
     FROM DW.DimTravelClass AS d
     JOIN DW.Temp_TravelClass_Dim AS t
       ON d.TravelClassKey = t.TravelClassID
     WHERE
       (
         ISNULL(d.ClassName, '') <> ISNULL(t.ClassName, '')
-        OR ISNULL(d.Capacity, -1) <> ISNULL(t.Capacity, -1) 
+        OR ISNULL(d.Capacity, -1) <> ISNULL(t.Capacity, -1)
       );
     SET @RowsUpdated = @@ROWCOUNT;
 
     INSERT INTO DW.DimTravelClass (
       TravelClassKey,
       ClassName,
-      Capacity 
+      Capacity
     )
     SELECT
       t.TravelClassID,
       t.ClassName,
-      t.Capacity 
+      t.Capacity
     FROM DW.Temp_TravelClass_Dim AS t
     WHERE NOT EXISTS (
       SELECT 1 FROM DW.DimTravelClass AS d

--- a/Datawarehouse/Dimensions/Initial_Airline_Dim.sql
+++ b/Datawarehouse/Dimensions/Initial_Airline_Dim.sql
@@ -41,8 +41,8 @@ BEGIN
       a.FleetSize,
       a.Website,
       a.Current_IATA_Code,
-      NULL,      
-      NULL      
+      NULL,
+      NULL
     FROM SA.Airline AS a;
 
     SET @RowsInserted = @@ROWCOUNT;

--- a/Datawarehouse/Dimensions/Initial_DateTime_Dim.sql
+++ b/Datawarehouse/Dimensions/Initial_DateTime_Dim.sql
@@ -1,7 +1,7 @@
 CREATE OR ALTER PROCEDURE [DW].[Initial_DateTime_Dim]
 AS
 BEGIN
-	
+
 	TRUNCATE TABLE [DW].[DimDateTime];
 
     WITH TimeCTE AS (
@@ -11,7 +11,7 @@ BEGIN
         FROM TimeCTE
         WHERE TimeValue < CAST('23:59' AS TIME)
     )
-    SELECT 
+    SELECT
         TimeValue,
         DATEPART(hour, TimeValue) AS HourValue,
         DATEPART(minute, TimeValue) AS MinuteValue
@@ -22,19 +22,19 @@ BEGIN
     DECLARE @CurrentMonthStart DATE;
     DECLARE @EndDate DATE;
 
-    SELECT 
-        @CurrentMonthStart = MIN(FullDateAlternateKey), 
+    SELECT
+        @CurrentMonthStart = MIN(FullDateAlternateKey),
         @EndDate = MAX(FullDateAlternateKey)
-    FROM 
+    FROM
         [DW].[DimDate]
 
 
     WHILE @CurrentMonthStart <= @EndDate
     BEGIN
-    
+
         DECLARE @CurrentMonthEnd DATE = EOMONTH(@CurrentMonthStart);
 		PRINT 'Processing month starting: ' + CONVERT(varchar, @CurrentMonthStart, 120);
-        
+
         INSERT INTO [DW].[DimDateTime] (
             [DateTimeKey],
             [FullDateAlternateKey], [PersianFullDateAlternateKey], [DayNumberOfWeek], [PersianDayNumberOfWeek],
@@ -47,23 +47,23 @@ BEGIN
         )
         SELECT
             CAST(d.[FullDateAlternateKey] AS DATETIME) + CAST(t.TimeValue AS DATETIME),
-            
+
             d.[FullDateAlternateKey], d.[PersianFullDateAlternateKey], d.[DayNumberOfWeek], d.[PersianDayNumberOfWeek],
             d.[EnglishDayNameOfWeek], d.[PersianDayNameOfWeek], d.[DayNumberOfMonth], d.[PersianDayNumberOfMonth],
             d.[DayNumberOfYear], d.[PersianDayNumberOfYear], d.[WeekNumberOfYear], d.[PersianWeekNumberOfYear],
             d.[EnglishMonthName], d.[PersianMonthName], d.[MonthNumberOfYear], d.[PersianMonthNumberOfYear],
             d.[CalendarQuarter], d.[PersianCalendarQuarter], d.[CalendarYear], d.[PersianCalendarYear],
             d.[CalendarSemester], d.[PersianCalendarSemester],
-            
+
             t.TimeValue,
             t.HourValue,
             t.MinuteValue
         FROM
-            [DW].[DimDate] d 
+            [DW].[DimDate] d
         CROSS JOIN
             #TimeDimension t
         WHERE
-            
+
             d.FullDateAlternateKey >= @CurrentMonthStart AND d.FullDateAlternateKey <= @CurrentMonthEnd;
 
         SET @CurrentMonthStart = DATEADD(month, 1, @CurrentMonthStart);

--- a/Datawarehouse/Dimensions/Initial_Date_Dim.sql
+++ b/Datawarehouse/Dimensions/Initial_Date_Dim.sql
@@ -3,13 +3,13 @@ AS
 BEGIN
 	TRUNCATE TABLE [DW].[DimDate];
 	BULK INSERT [DW].[DimDate]
-	FROM 'F:\UNI\Term8\DB2\Project\data-warehouse\Files\Date1.CSV' --'D:\Uni\Current Semester\DB2\Project\data-warehouse\Files\Date1.CSV' --'F:\UNI\Term8\DB2\Project\data-warehouse\Files\Date1.CSV'
-	WITH 
+	FROM 'F:\UNI\Term8\DB2\Project\data-warehouse\Files\Date1.CSV'
+	WITH
 	(
-		FIELDTERMINATOR = ',',   
-		ROWTERMINATOR = '\n',    
+		FIELDTERMINATOR = ',',
+		ROWTERMINATOR = '\n',
 		FIRSTROW = 2,
-		CODEPAGE = '65001'            
+		CODEPAGE = '65001'
 	)
 END
 GO

--- a/Datawarehouse/Dimensions/Initial_Flight_Dim.sql
+++ b/Datawarehouse/Dimensions/Initial_Flight_Dim.sql
@@ -35,12 +35,12 @@ BEGIN
     )
     SELECT
       f.FlightDetailID,
-      dep.City + ' Airport' AS DepartureAirportName,   
-      dest.City + ' Airport' AS DestinationAirportName, 
+      dep.City + ' Airport' AS DepartureAirportName,
+      dest.City + ' Airport' AS DestinationAirportName,
       f.DepartureDateTime,
       f.ArrivalDateTime,
       DATEDIFF(MINUTE, f.DepartureDateTime, f.ArrivalDateTime) AS FlightDurationMinutes,
-      a.Model AS AircraftName,        
+      a.Model AS AircraftName,
       f.FlightCapacity,
       f.TotalCost
     FROM SA.FlightDetail AS f

--- a/Datawarehouse/Dimensions/Initial_Payment_Dim.sql
+++ b/Datawarehouse/Dimensions/Initial_Payment_Dim.sql
@@ -2,7 +2,7 @@ CREATE OR ALTER PROCEDURE [DW].[Initial_Payment_Dim]
 AS
 BEGIN
   SET NOCOUNT ON;
-  
+
   DECLARE
     @StartTime    DATETIME2(3) = SYSUTCDATETIME(),
     @RowsInserted INT,

--- a/Datawarehouse/Dimensions/Initial_PointConversionRate_Dim.sql
+++ b/Datawarehouse/Dimensions/Initial_PointConversionRate_Dim.sql
@@ -35,8 +35,8 @@ BEGIN
             sa.ConversionRate,
             sa.CurrencyCode,
             '1950-01-01 00:00:00',
-            NULL,    
-            1        
+            NULL,
+            1
         FROM SA.PointConversionRate sa;
 
         SET @RowsInserted = @@ROWCOUNT;

--- a/Datawarehouse/Dimensions/Initial_ServiceOffering_Dim.sql
+++ b/Datawarehouse/Dimensions/Initial_ServiceOffering_Dim.sql
@@ -34,7 +34,7 @@ BEGIN
       so.ServiceOfferingID,
       so.OfferingName,
       so.Description,
-      tc.ClassName, 
+      tc.ClassName,
       so.TotalCost,
       ISNULL(
         STUFF((

--- a/Datawarehouse/Dimensions/Initial_TravelClass_Dim.sql
+++ b/Datawarehouse/Dimensions/Initial_TravelClass_Dim.sql
@@ -25,12 +25,12 @@ BEGIN
     INSERT INTO DW.DimTravelClass (
         TravelClassKey,
         ClassName,
-        Capacity 
+        Capacity
     )
     SELECT
         tc.TravelClassID,
         tc.ClassName,
-        tc.Capacity 
+        tc.Capacity
     FROM SA.TravelClass AS tc;
 
     SET @RowsInserted = @@ROWCOUNT;

--- a/Datawarehouse/Drop_DW_all.sql
+++ b/Datawarehouse/Drop_DW_all.sql
@@ -1,30 +1,30 @@
--- ========== DROP ALL FACT TABLES ==========
 
--- LoyaltyMart
+
+
 DROP TABLE IF EXISTS [DW].[LoyaltyPointTransaction_TransactionalFact];
 DROP TABLE IF EXISTS [DW].[CrewAssignmentEvent_Factless];
 DROP TABLE IF EXISTS [DW].[PersonPointTransactions_MonthlyFact];
 DROP TABLE IF EXISTS [DW].[PersonPointTransactions_ACCFact];
 
 
--- MaintenanceMart
+
 DROP TABLE IF EXISTS [DW].[AircraftHealth_MonthlyFact];
 DROP TABLE IF EXISTS [DW].[MaintenanceEvent_TransactionalFact];
 DROP TABLE IF EXISTS [DW].[PartReplacement_TransactionalFact];
 
--- PerformanceMart
+
 DROP TABLE IF EXISTS [DW].[FlightPerformance_TransactionalFact];
 DROP TABLE IF EXISTS [DW].[FlightDelay_DailyFact];
 DROP TABLE IF EXISTS [DW].[FlightDelay_ACCFact];
 DROP TABLE IF EXISTS [DW].[AirlineAndAirport_Factless];
 
--- RevenueMart
+
 DROP TABLE IF EXISTS [DW].[FlightOperation_Factless];
 DROP TABLE IF EXISTS [DW].[PassengerActivity_ACCFact];
 DROP TABLE IF EXISTS [DW].[PassengerTicket_TransactionalFact];
 DROP TABLE IF EXISTS [DW].[PassengerActivity_YearlyFact];
 
--- ========== DROP ALL DIMENSION TABLES ==========
+
 DROP TABLE IF EXISTS [DW].[DimAccount];
 DROP TABLE IF EXISTS [DW].[DimAircraft];
 DROP TABLE IF EXISTS [DW].[DimAirlineAirportService];
@@ -47,7 +47,7 @@ DROP TABLE IF EXISTS [DW].[DimServiceOffering];
 DROP TABLE IF EXISTS [DW].[DimTechnician];
 DROP TABLE IF EXISTS [DW].[DimTravelClass];
 
--- ========== DROP ALL TEMP TABLES ==========
+
 DROP TABLE IF EXISTS [DW].[Temp_Account_table];
 DROP TABLE IF EXISTS [DW].[Temp_Aircraft_table];
 DROP TABLE IF EXISTS [DW].[Temp_AirlineAirportService_table];
@@ -80,12 +80,12 @@ DROP TABLE IF EXISTS [DW].[Temp_TravelClass_Dim];
 DROP TABLE IF EXISTS [DW].[Temp_MaintenanceEvent_Batch];
 
 
--- ========== DROP ETL LOG ==========
+
 DROP TABLE IF EXISTS [DW].[ETL_Log];
 
--- ========== DROP ALL INITIAL/ETL/FACT LOAD PROCEDURES ==========
 
--- Dimensions: Initial & ETL
+
+
 IF OBJECT_ID('[DW].[Initial_Account_Dim]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Initial_Account_Dim];
 IF OBJECT_ID('[DW].[Initial_Aircraft_Dim]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Initial_Aircraft_Dim];
 IF OBJECT_ID('[DW].[Initial_AirlineAirportService_Dim]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Initial_AirlineAirportService_Dim];
@@ -134,9 +134,9 @@ IF OBJECT_ID('[DW].[ETL_TravelClass_Dim]', 'P') IS NOT NULL DROP PROCEDURE [DW].
 IF OBJECT_ID('[DW].[Main_Dim_Initial_ETL]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Main_Dim_Initial_ETL];
 
 
--- ====== FACT Initial & ETL Procedures ======
 
--- LoyaltyMart
+
+
 IF OBJECT_ID('[DW].[Load_LoyaltyPoint_TransactionalFact]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Load_LoyaltyPoint_TransactionalFact];
 IF OBJECT_ID('[DW].[Initial_LoyaltyPoint_TransactionalFact]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Initial_LoyaltyPoint_TransactionalFact];
 
@@ -151,7 +151,7 @@ IF OBJECT_ID('[DW].[Initial_PersonPointTransactions_ACCFact]', 'P') IS NOT NULL 
 
 
 
--- RevenueMart
+
 IF OBJECT_ID('[DW].[Load_FlightOperation_Factless]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Load_FlightOperation_Factless];
 IF OBJECT_ID('[DW].[Initial_FlightOperation_Factless]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Initial_FlightOperation_Factless];
 
@@ -164,7 +164,7 @@ IF OBJECT_ID('[DW].[Initial_PassengerTicket_TransactionalFact]', 'P') IS NOT NUL
 IF OBJECT_ID('[DW].[Load_PassengerActivity_YearlyFact]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Load_PassengerActivity_YearlyFact];
 IF OBJECT_ID('[DW].[Initial_PassengerActivity_YearlyFact]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Initial_PassengerActivity_YearlyFact];
 
--- PerformanceMart
+
 IF OBJECT_ID('[DW].[Load_FlightPerformance_TransactionalFact]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Load_FlightPerformance_TransactionalFact];
 IF OBJECT_ID('[DW].[Initial_FlightPerformance_TransactionalFact]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Initial_FlightPerformance_TransactionalFact];
 
@@ -177,21 +177,21 @@ IF OBJECT_ID('[DW].[Initial_FlightDelay_ACCFact]', 'P') IS NOT NULL DROP PROCEDU
 IF OBJECT_ID('[DW].[Load_AirlineAndAirport_Factless]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Load_AirlineAndAirport_Factless];
 IF OBJECT_ID('[DW].[Initial_AirlineAndAirport_Factless]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Initial_AirlineAndAirport_Factless];
 
--- MaintenanceMart
--- IF OBJECT_ID('[DW].[LoadFactAircraftHealthSnapshot_PeriodicSnapshot]', 'P') IS NOT NULL DROP PROCEDURE [DW].[LoadFactAircraftHealthSnapshot_PeriodicSnapshot];
--- IF OBJECT_ID('[DW].[InitialFactAircraftHealthSnapshot_PeriodicSnapshot]', 'P') IS NOT NULL DROP PROCEDURE [DW].[InitialFactAircraftHealthSnapshot_PeriodicSnapshot];
+
+
+
 
 IF OBJECT_ID('[DW].[Initial_MaintenanceEvent_TransactionalFact]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Initial_MaintenanceEvent_TransactionalFact];
--- IF OBJECT_ID('[DW].[InitialFactMaintenanceEvent_Transactional]', 'P') IS NOT NULL DROP PROCEDURE [DW].[InitialFactMaintenanceEvent_Transactional];
 
--- IF OBJECT_ID('[DW].[LoadFactPartReplacement_Transactional]', 'P') IS NOT NULL DROP PROCEDURE [DW].[LoadFactPartReplacement_Transactional];
--- IF OBJECT_ID('[DW].[InitialFactPartReplacement_Transactional]', 'P') IS NOT NULL DROP PROCEDURE [DW].[InitialFactPartReplacement_Transactional];
+
+
+
 
 IF OBJECT_ID('[DW].[Main_Fact_Initial_ETL]', 'P') IS NOT NULL DROP PROCEDURE [DW].[Main_Fact_Initial_ETL];
 
 
--- ====== Main ETL wrapper proc if any ======
+
 IF OBJECT_ID('[DW].[ALL_Initial_ETL]', 'P') IS NOT NULL DROP PROCEDURE [DW].[ALL_Initial_ETL];
 
--- ========== DROP SCHEMA LAST ==========
+
 DROP SCHEMA IF EXISTS [DW];

--- a/Datawarehouse/Facts/LoyaltyMart/Create_LoyaltyPointTransaction_TransactionalFact.sql
+++ b/Datawarehouse/Facts/LoyaltyMart/Create_LoyaltyPointTransaction_TransactionalFact.sql
@@ -1,20 +1,20 @@
 CREATE TABLE [DW].[LoyaltyPointTransaction_TransactionalFact] (
-    -- Dimensional Surrogate Keys
-    [TransactionDateKey] datetime NOT NULL,             -- From PointsTransaction.TransactionDate, FK to DimDateTime
-    [PersonKey] int NOT NULL,                           -- Resolved via Account -> Passenger -> Person, FK to DimPerson
-    [AccountKey] int NOT NULL,                          -- PointsTransaction.AccountID, FK to DimAccount
-    [LoyaltyTierKey] int NOT NULL,                      -- Tier active at TransactionDate, FK to DimLoyaltyTier
-    [TransactionTypeKey] int NOT NULL,                  -- PointsTransaction.LoyaltyTransactionTypeID, FK to DimLoyaltyTransactionType
-    [ConversionRateKey] int NULL,                       -- PointsTransaction.PointConversionRateID, FK to DimPointConversionRate (nullable)
-    [FlightKey] int NULL,                               -- PointsTransaction.FlightDetailID, FK to DimFlight (nullable)
-    [ServiceOfferingKey] int NULL,                      -- PointsTransaction.ServiceOfferingID, FK to DimServiceOffering (nullable)
 
-    -- Business Measures
-    [PointsEarned] decimal(18,2) NULL,                  -- If PointsTransaction.PointsChange > 0, set to PointsChange; otherwise, NULL or 0
-    [PointsRedeemed] decimal(18,2) NULL,                -- If PointsTransaction.PointsChange < 0, set to ABS(PointsChange); otherwise, NULL or 0
-    [CurrencyValue] decimal(18,2) NULL,                 -- Direct from PointsTransaction.CurrencyValue
-    [ConversionRateSnapshot] decimal(18,6) NULL,        -- Direct from PointsTransaction.ConversionRate
-    [BalanceAfterTransaction] decimal(18,2) NULL,       -- Direct from PointsTransaction.BalanceAfterTransaction
+    [TransactionDateKey] datetime NOT NULL,
+    [PersonKey] int NOT NULL,
+    [AccountKey] int NOT NULL,
+    [LoyaltyTierKey] int NOT NULL,
+    [TransactionTypeKey] int NOT NULL,
+    [ConversionRateKey] int NULL,
+    [FlightKey] int NULL,
+    [ServiceOfferingKey] int NULL,
+
+
+    [PointsEarned] decimal(18,2) NULL,
+    [PointsRedeemed] decimal(18,2) NULL,
+    [CurrencyValue] decimal(18,2) NULL,
+    [ConversionRateSnapshot] decimal(18,6) NULL,
+    [BalanceAfterTransaction] decimal(18,2) NULL,
 )
 GO
 

--- a/Datawarehouse/Facts/LoyaltyMart/ETL_CrewAssignmentEvent_Factless.sql
+++ b/Datawarehouse/Facts/LoyaltyMart/ETL_CrewAssignmentEvent_Factless.sql
@@ -7,13 +7,13 @@ BEGIN
 	DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 	DECLARE @RowCount INT;
 
-	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 	VALUES ('Load_CrewAssignmentEvent_Factless', 'CrewAssignmentEvent_Factless', 'Procedure started for incremental merge', @StartTime, 'Running');
-		
+
 	SET @LogID = SCOPE_IDENTITY();
 
 	BEGIN TRY
-		
+
 		MERGE [DW].[CrewAssignmentEvent_Factless] AS Target
 		USING (
 			SELECT

--- a/Datawarehouse/Facts/LoyaltyMart/Initial_CrewAssignmentEvent_Factless.sql
+++ b/Datawarehouse/Facts/LoyaltyMart/Initial_CrewAssignmentEvent_Factless.sql
@@ -7,9 +7,9 @@ BEGIN
 	DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 	DECLARE @RowCount INT;
 
-	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 	VALUES ('Initial_CrewAssignmentEvent_Factless', 'CrewAssignmentEvent_Factless', 'Procedure started for initial full load', @StartTime, 'Running');
-		
+
 	SET @LogID = SCOPE_IDENTITY();
 
 	BEGIN TRY

--- a/Datawarehouse/Facts/LoyaltyMart/Initial_PersonPointTransactions_ACCFact.sql
+++ b/Datawarehouse/Facts/LoyaltyMart/Initial_PersonPointTransactions_ACCFact.sql
@@ -7,9 +7,9 @@ BEGIN
 	DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 	DECLARE @RowCount INT;
 
-	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 	VALUES ('Initial_PersonPointTransactions_ACCFact', 'PersonPointTransactions_ACCFact', 'Procedure started for initial full load', @StartTime, 'Running');
-		
+
 	SET @LogID = SCOPE_IDENTITY();
 
 	BEGIN TRY
@@ -50,7 +50,7 @@ BEGIN
 			agg.TotalPointValueUSD,
 			agg.TotalNumberOfTransactions,
 			agg.TotalDistinctFlightsEarnedOn
-		FROM 
+		FROM
 			LifetimeAggregates agg
         LEFT JOIN LatestTier lt ON agg.PersonID = lt.PersonID AND lt.rn = 1
         INNER JOIN [DW].[DimPerson] current_person ON agg.PersonID = current_person.PersonID AND current_person.EffectiveTo IS NULL;

--- a/Datawarehouse/Facts/MaintenanceMart/Create_MaintenanceEvent_TransactionalFact.sql
+++ b/Datawarehouse/Facts/MaintenanceMart/Create_MaintenanceEvent_TransactionalFact.sql
@@ -1,17 +1,17 @@
 CREATE TABLE [DW].[MaintenanceEvent_TransactionalFact] (
-    -- Dimensional Keys
-    [AircraftID]                INT NOT NULL,   -- FK to DW.DimAircraft.AircraftID, from SA.MaintenanceEvent.AircraftID
-    [MaintenanceTypeID]         integer NOT NULL,   -- FK to DW.DimMaintenanceType.MaintenanceTypeID, from SA.MaintenanceEvent.MaintenanceTypeID
-    [LocationKey]    INT NOT NULL,   -- FK to DW.DimMaintenanceLocation.LocationKey (SCD2), lookup by Location+Date from SA.MaintenanceEvent.LocationID & MaintenanceDate
-    [TechnicianID]              integer NOT NULL,   -- FK to DW.DimTechnician.TechnicianID, from SA.MaintenanceEvent.TechnicianID
-    [MaintenanceDateKey]        datetime NOT NULL,   -- FK to DW.DimDateTime.DateKey, from SA.MaintenanceEvent.MaintenanceDate
 
-    -- Business Measures
-    [DowntimeHours]             FLOAT NULL,         -- Direct from SA.MaintenanceEvent.DowntimeHours
-    [LaborHours]                FLOAT NULL,         -- Direct from SA.MaintenanceEvent.LaborHours
-    [LaborCost]                 DECIMAL(18,2) NULL, -- Direct from SA.MaintenanceEvent.LaborCost
-    [TotalPartsCost]            DECIMAL(18,2) NULL, -- Direct from SA.MaintenanceEvent.TotalPartsCost
-    [TotalMaintenanceCost]      DECIMAL(18,2) NULL, -- Direct from SA.MaintenanceEvent.TotalMaintenanceCost
-    [DistinctIssuesSolved]      INT NULL            -- Direct from SA.MaintenanceEvent.DistinctIssuesSolved, or COUNT of related resolved issues if normalized
+    [AircraftID]                INT NOT NULL,
+    [MaintenanceTypeID]         integer NOT NULL,
+    [LocationKey]    INT NOT NULL,
+    [TechnicianID]              integer NOT NULL,
+    [MaintenanceDateKey]        datetime NOT NULL,
+
+
+    [DowntimeHours]             FLOAT NULL,
+    [LaborHours]                FLOAT NULL,
+    [LaborCost]                 DECIMAL(18,2) NULL,
+    [TotalPartsCost]            DECIMAL(18,2) NULL,
+    [TotalMaintenanceCost]      DECIMAL(18,2) NULL,
+    [DistinctIssuesSolved]      INT NULL
 );
 GO

--- a/Datawarehouse/Facts/MaintenanceMart/Initial_MaintenanceEvent_TransactionalFact.sql
+++ b/Datawarehouse/Facts/MaintenanceMart/Initial_MaintenanceEvent_TransactionalFact.sql
@@ -5,7 +5,7 @@ BEGIN
 
     DECLARE @CurrentDate DATE;
 
-    -- Use a cursor to process only distinct event dates present in the data
+
     DECLARE date_cursor CURSOR FOR
         SELECT DISTINCT MaintenanceDate FROM [SA].[MaintenanceEvent] ORDER BY MaintenanceDate;
 
@@ -33,18 +33,18 @@ BEGIN
             TRUNCATE TABLE DW.Temp_MaintenanceEvent_Batch;
 
             INSERT INTO DW.Temp_MaintenanceEvent_Batch (
-                MaintenanceEventID, AircraftID, MaintenanceTypeID, LocationID, TechnicianID, MaintenanceDate, 
+                MaintenanceEventID, AircraftID, MaintenanceTypeID, LocationID, TechnicianID, MaintenanceDate,
                 DowntimeHours, LaborHours, LaborCost, TotalPartsCost, TotalMaintenanceCost, DistinctIssuesSolved
             )
             SELECT
-                MaintenanceEventID, AircraftID, MaintenanceTypeID, LocationID, TechnicianID, MaintenanceDate, 
+                MaintenanceEventID, AircraftID, MaintenanceTypeID, LocationID, TechnicianID, MaintenanceDate,
                 DowntimeHours, LaborHours, LaborCost, TotalPartsCost, TotalMaintenanceCost, DistinctIssuesSolved
             FROM [SA].[MaintenanceEvent]
             WHERE MaintenanceDate = @CurrentDate;
 
             IF @@ROWCOUNT = 0
             BEGIN
-                -- This branch should rarely be hit now, since we're looping only over dates with data.
+
                 UPDATE DW.ETL_Log
                 SET ChangeDescription = 'No maintenance events found for date: ' + CONVERT(varchar, @CurrentDate, 101),
                     RowsAffected = 0,

--- a/Datawarehouse/Facts/PerformanceMart/Create_FlightDelay_ACCFact.sql
+++ b/Datawarehouse/Facts/PerformanceMart/Create_FlightDelay_ACCFact.sql
@@ -1,7 +1,7 @@
-CREATE TABLE [DW].[FlightDelay_ACCFact] (  
-    [AirlineID]              INT    NOT NULL,  
-    [DepartureAirportID]     INT    NOT NULL,  
-    [ArrivalAirportID]       INT    NOT NULL,  
+CREATE TABLE [DW].[FlightDelay_ACCFact] (
+    [AirlineID]              INT    NOT NULL,
+    [DepartureAirportID]     INT    NOT NULL,
+    [ArrivalAirportID]       INT    NOT NULL,
 
     [TotalFlightsNumber]            INT    NULL,
     [TotalDelayedFlightsNumber]          INT    NULL,

--- a/Datawarehouse/Facts/PerformanceMart/Create_FlightDelay_DailyFact.sql
+++ b/Datawarehouse/Facts/PerformanceMart/Create_FlightDelay_DailyFact.sql
@@ -1,8 +1,8 @@
 CREATE TABLE [DW].[FlightDelay_DailyFact] (
-    [DateID]         DATE    NOT NULL,  
-    [AirlineID]              INT    NOT NULL,  
-    [DepartureAirportID]     INT    NOT NULL,  
-    [ArrivalAirportID]       INT    NOT NULL,  
+    [DateID]         DATE    NOT NULL,
+    [AirlineID]              INT    NOT NULL,
+    [DepartureAirportID]     INT    NOT NULL,
+    [ArrivalAirportID]       INT    NOT NULL,
 
     [DailyFlightsNumber]            INT    NULL,
     [DailyDelayedFlightsNumber]          INT    NULL,

--- a/Datawarehouse/Facts/PerformanceMart/Create_FlightPerformance_TransactionalFact.sql
+++ b/Datawarehouse/Facts/PerformanceMart/Create_FlightPerformance_TransactionalFact.sql
@@ -1,24 +1,24 @@
 CREATE TABLE [DW].[FlightPerformance_TransactionalFact] (
-    [ScheduledDepartureId] DATETIME NULL,  -- from SA.FlightDetail.ScheduledDepartureDateTime
-    [ScheduledArrivalId]   DATETIME NULL,  -- from SA.FlightDetail.ScheduledArrivalDateTime
+    [ScheduledDepartureId] DATETIME NULL,
+    [ScheduledArrivalId]   DATETIME NULL,
 
-    [ActualDepartureId]    DATETIME NULL,  -- from SA.FlightOperation.ActualDepartureDateTime
-    [ActualArrivalId]      DATETIME NULL,  -- from SA.FlightOperation.ActualArrivalDateTime
+    [ActualDepartureId]    DATETIME NULL,
+    [ActualArrivalId]      DATETIME NULL,
 
-    [DepartureAirportId]   INT NULL,       -- from SA.FlightDetail.DepartureAirportID
-    [ArrivalAirportId]     INT NULL,       -- from SA.FlightDetail.ArrivalAirportID
+    [DepartureAirportId]   INT NULL,
+    [ArrivalAirportId]     INT NULL,
 
-    [AircraftId]           INT NULL,       -- from SA.FlightDetail.AircraftID
-    [AirlineId]            INT NULL,       -- from SA.FlightDetail.AirlineID
+    [AircraftId]           INT NULL,
+    [AirlineId]            INT NULL,
 
-    [DepartureDelayMinutes] INT NULL,      -- from SA.FlightOperation.DelayMinutes
-    [ArrivalDelayMinutes]  INT NULL,       -- from SA.FlightOperation.DelayMinutes
+    [DepartureDelayMinutes] INT NULL,
+    [ArrivalDelayMinutes]  INT NULL,
 
-    [FlightDurationActual]   INT NULL,     -- Actual flight duration in minutes (DATEDIFF in ETL)
-    [FlightDurationScheduled] INT NULL,    -- Scheduled flight duration in minutes (DATEDIFF in ETL)
+    [FlightDurationActual]   INT NULL,
+    [FlightDurationScheduled] INT NULL,
 
-    [LoadFactor]            FLOAT NULL,    -- from SA.FlightOperation.LoadFactor
-    [DelaySeverityScore]    FLOAT NULL     -- from SA.FlightOperation.DelaySeverityScore
+    [LoadFactor]            FLOAT NULL,
+    [DelaySeverityScore]    FLOAT NULL
 );
 GO
 

--- a/Datawarehouse/Facts/PerformanceMart/ETL_AirlineAndAirport_Factless.sql
+++ b/Datawarehouse/Facts/PerformanceMart/ETL_AirlineAndAirport_Factless.sql
@@ -7,21 +7,21 @@ BEGIN
 	DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 	DECLARE @RowCount INT;
 
-	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 	VALUES ('Load_AirlineAndAirport_Factless', 'AirlineAndAirport_Factless', 'Procedure started for incremental merge', @StartTime, 'Running');
-		
+
 	SET @LogID = SCOPE_IDENTITY();
 
 	BEGIN TRY
-		
+
 		MERGE [DW].[AirlineAndAirport_Factless] AS Target
 		USING (
-			-- The source is the complete, distinct set of current relationships
+
 			SELECT DISTINCT
 				AirlineID,
 				AirportID
 			FROM (
-				-- Select all departure relationships
+
 				SELECT
 					ac.AirlineID,
 					fd.DepartureAirportID AS AirportID
@@ -29,7 +29,7 @@ BEGIN
 					[SA].[FlightDetail] fd
 				INNER JOIN
 					[SA].[Aircraft] ac ON fd.AircraftID = ac.AircraftID
-				
+
 				UNION
 
 				SELECT

--- a/Datawarehouse/Facts/PerformanceMart/ETL_FlightDelay_ACCFact.sql
+++ b/Datawarehouse/Facts/PerformanceMart/ETL_FlightDelay_ACCFact.sql
@@ -7,16 +7,16 @@ BEGIN
 	DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 	DECLARE @RowCount INT;
 
-	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 	VALUES ('Load_FlightDelay_ACCFact', 'FlightDelay_ACCFact', 'Procedure started for incremental merge', @StartTime, 'Running');
-		
+
 	SET @LogID = SCOPE_IDENTITY();
 
 	BEGIN TRY
 
 		MERGE [DW].[FlightDelay_ACCFact] AS Target
 		USING (
-			-- The source is the full lifetime aggregation from the SA tables
+
 			SELECT
 				ac.AirlineID,
 				fd.DepartureAirportID,
@@ -26,9 +26,9 @@ BEGIN
 				SUM(CASE WHEN fo.CancelFlag = 1 THEN 1 ELSE 0 END) AS TotalCancelledFlightsNumber,
 				AVG(CAST(fo.DelayMinutes AS FLOAT)) AS TotalAvgDepartureDelayMinutes,
 				MAX(fo.DelayMinutes) AS TotalMaxDelayMinutes
-			FROM 
+			FROM
 				[SA].[FlightOperation] fo
-			INNER JOIN 
+			INNER JOIN
 				[SA].[FlightDetail] fd ON fo.FlightDetailID = fd.FlightDetailID
 			INNER JOIN
 				[SA].[Aircraft] ac ON fd.AircraftID = ac.AircraftID

--- a/Datawarehouse/Facts/PerformanceMart/ETL_FlightDelay_DailyFact.sql
+++ b/Datawarehouse/Facts/PerformanceMart/ETL_FlightDelay_DailyFact.sql
@@ -17,7 +17,7 @@ BEGIN
     BEGIN
         SET @StartDate = DATEADD(day, 1, @StartDate);
     END;
-	
+
 	IF @StartDate > @EndDate
 	BEGIN
 		RAISERROR('The FlightDelay_DailyFact table is up to date!', 0, 1) WITH NOWAIT;
@@ -25,19 +25,19 @@ BEGIN
 	END
 
 	DECLARE @CurrentDate date = @StartDate;
-	
+
 	WHILE @CurrentDate <= @EndDate
 	BEGIN
 		DECLARE @LogID BIGINT;
 		DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 		DECLARE @RowCount INT;
 
-		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 		VALUES ('Load_FlightDelay_DailyFact', 'FlightDelay_DailyFact', 'Procedure started for date: ' + CONVERT(varchar, @CurrentDate, 101), @StartTime, 'Running');
-			
+
 		SET @LogID = SCOPE_IDENTITY();
 
-		BEGIN TRY            
+		BEGIN TRY
 			WITH DailyAggregates AS (
 				SELECT
 					ac.AirlineID, fd.DepartureAirportID, fd.DestinationAirportID,

--- a/Datawarehouse/Facts/PerformanceMart/ETL_FlightPerformance_TransactionalFact.sql
+++ b/Datawarehouse/Facts/PerformanceMart/ETL_FlightPerformance_TransactionalFact.sql
@@ -7,14 +7,14 @@ BEGIN
 	DECLARE @EndDate date;
 
 
-    SELECT 
+    SELECT
         @StartDate = MAX(CAST(ActualDepartureId AS DATE))
-    FROM 
+    FROM
         [DW].[FlightPerformance_TransactionalFact];
 
-	SELECT 
+	SELECT
 		@EndDate = MAX(CAST(ActualDepartureDateTime AS DATE))
-	FROM 
+	FROM
 		[SA].[FlightOperation];
 
 	IF @StartDate IS NULL
@@ -30,25 +30,25 @@ BEGIN
 	END
 
 	DECLARE @CurrentDate date = @StartDate;
-	
+
 	WHILE @CurrentDate <= @EndDate
 	BEGIN
 		DECLARE @LogID BIGINT;
 		DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 		DECLARE @RowCount INT;
 
-		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 		VALUES ('LoadFactFlightPerformance', 'FlightPerformance_TransactionalFact', 'Procedure started for date: ' + CONVERT(varchar, @CurrentDate, 101), @StartTime, 'Running');
-		
+
 		SET @LogID = SCOPE_IDENTITY();
 
-		BEGIN TRY			
+		BEGIN TRY
 			INSERT INTO [DW].[Temp_DailyFlightOperations] (FlightOperationID, FlightDetailID, ActualDepartureDateTime, ActualArrivalDateTime, DelayMinutes, LoadFactor, DelaySeverityScore)
 			SELECT FlightOperationID, FlightDetailID, ActualDepartureDateTime, ActualArrivalDateTime, DelayMinutes, LoadFactor, DelaySeverityScore
 			FROM [SA].[FlightOperation]
 			WHERE CAST(ActualDepartureDateTime AS DATE) = @CurrentDate;
 
-			IF @@ROWCOUNT = 0 
+			IF @@ROWCOUNT = 0
 			BEGIN
 				UPDATE DW.ETL_Log SET ChangeDescription = 'No flight operations found for date: ' + CONVERT(varchar, @CurrentDate, 101), RowsAffected = 0, DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), Status = 'Success' WHERE LogID = @LogID;
 				SET @CurrentDate = DATEADD(day, 1, @CurrentDate);
@@ -72,7 +72,7 @@ BEGIN
 			FROM [DW].[Temp_DailyFlightOperations] fo
 			INNER JOIN [SA].[FlightDetail] fd ON fo.FlightDetailID = fd.FlightDetailID
             INNER JOIN [SA].[Aircraft] ac ON fd.AircraftID = ac.AircraftID;
-			
+
 			INSERT INTO [DW].[FlightPerformance_TransactionalFact] (
                 ScheduledDepartureId, ScheduledArrivalId, ActualDepartureId, ActualArrivalId,
                 DepartureAirportId, ArrivalAirportId, AircraftId, AirlineId,
@@ -80,23 +80,23 @@ BEGIN
                 LoadFactor, DelaySeverityScore
             )
 			SELECT
-				-- IDs and Keys
+
 				ef.ScheduledDepartureDateTime, ef.ScheduledArrivalDateTime, ef.ActualDepartureDateTime, ef.ActualArrivalDateTime,
                 ef.DepartureAirportID, ef.ArrivalAirportID, ef.AircraftID, ef.AirlineID,
-                -- Measures
-                ef.DelayMinutes, 
+
+                ef.DelayMinutes,
                 ef.DelayMinutes,
                 DATEDIFF(MINUTE, ef.ActualDepartureDateTime, ef.ActualArrivalDateTime),
-                DATEDIFF(MINUTE, ef.ScheduledDepartureDateTime, ef.ScheduledArrivalDateTime), 
+                DATEDIFF(MINUTE, ef.ScheduledDepartureDateTime, ef.ScheduledArrivalDateTime),
                 ef.LoadFactor,
                 ef.DelaySeverityScore
 			FROM [DW].[Temp_EnrichedFlightPerformanceData] ef;
-			
+
 			SET @RowCount = @@ROWCOUNT;
 
 			TRUNCATE TABLE [DW].[Temp_DailyFlightOperations];
 			TRUNCATE TABLE [DW].[Temp_EnrichedFlightPerformanceData];
-			
+
 			UPDATE DW.ETL_Log SET ChangeDescription = 'Load complete for date: ' + CONVERT(varchar, @CurrentDate, 101), RowsAffected = @RowCount, DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), Status = 'Success' WHERE LogID = @LogID;
 
 		END TRY

--- a/Datawarehouse/Facts/PerformanceMart/Initial_AirlineAndAirport_Factless.sql
+++ b/Datawarehouse/Facts/PerformanceMart/Initial_AirlineAndAirport_Factless.sql
@@ -7,14 +7,14 @@ BEGIN
 	DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 	DECLARE @RowCount INT;
 
-	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 	VALUES ('Initial_AirlineAndAirport_Factless', 'AirlineAndAirport_Factless', 'Procedure started for initial full load', @StartTime, 'Running');
-		
+
 	SET @LogID = SCOPE_IDENTITY();
 
 	BEGIN TRY
 		WITH AirlineAirportRelations AS (
-			-- Select all departure relationships
+
 			SELECT
 				ac.AirlineID,
 				fd.DepartureAirportID AS AirportID
@@ -22,8 +22,8 @@ BEGIN
 				[SA].[FlightDetail] fd
 			INNER JOIN
 				[SA].[Aircraft] ac ON fd.AircraftID = ac.AircraftID
-			
-			UNION 
+
+			UNION
 
 			SELECT
 				ac.AirlineID,
@@ -40,7 +40,7 @@ BEGIN
 		SELECT DISTINCT
 			AirlineID,
 			AirportID
-		FROM 
+		FROM
 			AirlineAirportRelations;
 
 

--- a/Datawarehouse/Facts/PerformanceMart/Initial_FlightDelay_ACCFact.sql
+++ b/Datawarehouse/Facts/PerformanceMart/Initial_FlightDelay_ACCFact.sql
@@ -7,9 +7,9 @@ BEGIN
 	DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 	DECLARE @RowCount INT;
 
-	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 	VALUES ('Initial_FlightDelay_ACCFact', 'FlightDelay_ACCFact', 'Procedure started for initial full load', @StartTime, 'Running');
-		
+
 	SET @LogID = SCOPE_IDENTITY();
 
 	BEGIN TRY
@@ -23,9 +23,9 @@ BEGIN
 				SUM(CASE WHEN fo.CancelFlag = 1 THEN 1 ELSE 0 END) AS TotalCancelledFlightsNumber,
 				AVG(CAST(fo.DelayMinutes AS FLOAT)) AS TotalAvgDepartureDelayMinutes,
 				MAX(fo.DelayMinutes) AS TotalMaxDelayMinutes
-			FROM 
+			FROM
 				[SA].[FlightOperation] fo
-			INNER JOIN 
+			INNER JOIN
 				[SA].[FlightDetail] fd ON fo.FlightDetailID = fd.FlightDetailID
 			INNER JOIN
 				[SA].[Aircraft] ac ON fd.AircraftID = ac.AircraftID

--- a/Datawarehouse/Facts/PerformanceMart/Initial_FlightDelay_DailyFact.sql
+++ b/Datawarehouse/Facts/PerformanceMart/Initial_FlightDelay_DailyFact.sql
@@ -6,14 +6,14 @@ BEGIN
 	DECLARE @StartDate date;
 	DECLARE @EndDate date;
 
-	SELECT 
+	SELECT
 		@StartDate = MIN(CAST(ActualDepartureDateTime AS DATE)),
 		@EndDate = MAX(CAST(ActualDepartureDateTime AS DATE))
-	FROM 
+	FROM
 		[SA].[FlightOperation]
     WHERE
         ActualDepartureDateTime IS NOT NULL;
-	
+
 	IF @StartDate IS NULL
 	BEGIN
 		RAISERROR('No valid flight operations data found to process.', 0, 1) WITH NOWAIT;
@@ -28,9 +28,9 @@ BEGIN
 		DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 		DECLARE @RowCount INT;
 
-		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 		VALUES ('Initial_FlightDelay_DailyFact', 'FlightDelay_DailyFact', 'Procedure started for date: ' + CONVERT(varchar, @CurrentDate, 101), @StartTime, 'Running');
-			
+
 		SET @LogID = SCOPE_IDENTITY();
 
 		BEGIN TRY
@@ -44,13 +44,13 @@ BEGIN
 					SUM(CASE WHEN fo.CancelFlag = 1 THEN 1 ELSE 0 END) AS DailyCancelledFlightsNumber,
 					AVG(CAST(fo.DelayMinutes AS FLOAT)) AS DailyAvgDepartureDelayMinutes,
 					MAX(fo.DelayMinutes) AS DailyMaxDelayMinutes
-				FROM 
+				FROM
 					[SA].[FlightOperation] fo
-				INNER JOIN 
+				INNER JOIN
 					[SA].[FlightDetail] fd ON fo.FlightDetailID = fd.FlightDetailID
 				INNER JOIN
 					[SA].[Aircraft] ac ON fd.AircraftID = ac.AircraftID
-				WHERE 
+				WHERE
 					CAST(fo.ActualDepartureDateTime AS DATE) = @CurrentDate
 				GROUP BY
 					ac.AirlineID,

--- a/Datawarehouse/Facts/RevenueMart/Create_PassengerActivity_ACCFact.sql
+++ b/Datawarehouse/Facts/RevenueMart/Create_PassengerActivity_ACCFact.sql
@@ -1,5 +1,5 @@
 CREATE TABLE [DW].[PassengerActivity_ACCFact] (
-    [PersonKey]              INT PRIMARY KEY,       -- The CURRENT surrogate key for the person
+    [PersonKey]              INT PRIMARY KEY,
     [TotalTicketValue]       INT NULL,
     [TotalAmountPaid]        DECIMAL(18, 2) NULL,
     [TotalMilesFlown]        DECIMAL(18, 2) NULL,
@@ -11,4 +11,4 @@ CREATE TABLE [DW].[PassengerActivity_ACCFact] (
     [MaxFlightDistance]      DECIMAL(18, 2) NULL,
     [MinFlightDistance]      DECIMAL(18, 2) NULL
 );
-GO 
+GO

--- a/Datawarehouse/Facts/RevenueMart/Create_PassengerActivity_YearlyFact.sql
+++ b/Datawarehouse/Facts/RevenueMart/Create_PassengerActivity_YearlyFact.sql
@@ -1,15 +1,15 @@
 CREATE TABLE [DW].[PassengerActivity_YearlyFact] (
-  [YearID] date, --first day of year
-  [PersonKey] int, -- The ticket holder
-  [YearlyTicketValue] decimal(18,2),  -- Sum of TotalAmountPaid
-  [YearlyMilesFlown] decimal(18,2), -- Sum of MilesFlown
-  [YearlyDiscountAmount] decimal(18,2), -- Sum of DiscountAmount
-  [YearlyAverageTicketPrice] decimal(18,2),  -- Avg of TicketPrice
-  [YearlyDistinctAirlinesUsed] int,  -- COUNT(DISTINCT AirlineKey)
-  [YearlyDistinctRoutesFlown] int,  -- COUNT(DISTINCT SourceAirportKey + DestinationAirportKey)
-  [YearlyFlights] decimal(18,2),  -- COUNT(DISTINCT FlightKey)
-  [YearlyMaxFlightDistance] decimal(18,2), -- MAX(MilesFlown)
-  [YearlyMinFlightDistance] decimal(18,2)  -- MIN(MilesFlown)
+  [YearID] date,
+  [PersonKey] int,
+  [YearlyTicketValue] decimal(18,2),
+  [YearlyMilesFlown] decimal(18,2),
+  [YearlyDiscountAmount] decimal(18,2),
+  [YearlyAverageTicketPrice] decimal(18,2),
+  [YearlyDistinctAirlinesUsed] int,
+  [YearlyDistinctRoutesFlown] int,
+  [YearlyFlights] decimal(18,2),
+  [YearlyMaxFlightDistance] decimal(18,2),
+  [YearlyMinFlightDistance] decimal(18,2)
 )
 GO
 

--- a/Datawarehouse/Facts/RevenueMart/Create_PassengerTicket_TransactionalFact.sql
+++ b/Datawarehouse/Facts/RevenueMart/Create_PassengerTicket_TransactionalFact.sql
@@ -10,14 +10,14 @@ CREATE TABLE [DW].[PassengerTicket_TransactionalFact] (
   [SourceAirportKey] int,
   [DestinationAirportKey] int,
   [TravelClassKey] [int] ,
-  [TicketRealPrice] decimal(18,2), -- Price before discounts and taxes (from Payment.RealPrice)
-  [TaxAmount] decimal(18,2),  -- Tax applied (it % is writen in Payment.Tax)
-  [DiscountAmount] decimal(18,2),   -- Total discount given (from Payment.Discount)
-  [TicketPrice] decimal(18,2),  -- Final paid amount (from Payment.TicketPrice)
-  [FlightCost] decimal(18,2),  -- Allocated flight cost for this ticket (TotalCost ÷ Capacity) should be fetch from FlightDetail
-  [FlightClassPrice] decimal(18,2), -- attributed to class type of the ticket (can match TravelClass.Cost)
-  [FlightRevenue] decimal(18,2),  -- Total revenue from this ticket (class + ticket - cost)
-  [kilometersFlown] decimal(18,2)  -- Distance flown (from FlightDetail.DistanceKM)
+  [TicketRealPrice] decimal(18,2),
+  [TaxAmount] decimal(18,2),
+  [DiscountAmount] decimal(18,2),
+  [TicketPrice] decimal(18,2),
+  [FlightCost] decimal(18,2),
+  [FlightClassPrice] decimal(18,2),
+  [FlightRevenue] decimal(18,2),
+  [kilometersFlown] decimal(18,2)
 )
 GO
 

--- a/Datawarehouse/Facts/RevenueMart/ETL_FlightOperation_Factless.sql
+++ b/Datawarehouse/Facts/RevenueMart/ETL_FlightOperation_Factless.sql
@@ -6,13 +6,13 @@ BEGIN
 	DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 	DECLARE @RowCount INT;
 
-	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 	VALUES ('Load_FlightOperation_Factless', 'FlightOperation_Factless', 'Procedure started for incremental merge', @StartTime, 'Running');
-		
+
 	SET @LogID = SCOPE_IDENTITY();
 
 	BEGIN TRY
-		
+
 		MERGE [DW].[FactFlightOperation_Factless] AS Target
 		USING (
 			SELECT
@@ -22,9 +22,9 @@ BEGIN
 				ac.AirlineID AS AirlineKey,
 				fd.AircraftID AS AircraftKey,
 				CASE
-					WHEN fo.CancelFlag = 1 THEN 3 -- Canceled
-					WHEN fo.DelayMinutes > 0 THEN 2 -- Delayed
-					ELSE 1 -- On-Time
+					WHEN fo.CancelFlag = 1 THEN 3
+					WHEN fo.DelayMinutes > 0 THEN 2
+					ELSE 1
 				END AS OperationTypeKey
 			FROM
 				[SA].[FlightOperation] fo

--- a/Datawarehouse/Facts/RevenueMart/ETL_PassengerActivity_ACCFact.sql
+++ b/Datawarehouse/Facts/RevenueMart/ETL_PassengerActivity_ACCFact.sql
@@ -7,13 +7,13 @@ BEGIN
 	DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 	DECLARE @RowCount INT;
 
-	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+	INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 	VALUES ('Load_PassengerActivity_ACCFact', 'PassengerActivity_ACCFact', 'Procedure started for incremental merge', @StartTime, 'Running');
-		
+
 	SET @LogID = SCOPE_IDENTITY();
 
 	BEGIN TRY
-		
+
 		TRUNCATE TABLE [DW].[Temp_LifetimeSourceData];
 
 		WITH LifetimeSummableAggregates AS (

--- a/Datawarehouse/Facts/RevenueMart/ETL_PassengerTicket_TransactionalFact.sql
+++ b/Datawarehouse/Facts/RevenueMart/ETL_PassengerTicket_TransactionalFact.sql
@@ -6,14 +6,14 @@ BEGIN
 	DECLARE @StartDate date;
 	DECLARE @EndDate date;
 
-    SELECT 
+    SELECT
         @EndDate = MAX(CAST(PaymentDateTime AS DATE))
-    FROM 
+    FROM
         [SA].[Payment]
 
-    SELECT 
+    SELECT
         @StartDate = MAX(CAST(PaymentDateKey AS DATE))
-    FROM 
+    FROM
         [DW].[PassengerTicket_TransactionalFact]
 
 	IF @StartDate IS NULL
@@ -29,26 +29,26 @@ BEGIN
 	END
 
 	DECLARE @CurrentDate date = @StartDate;
-	
+
 	WHILE @CurrentDate <= @EndDate
 	BEGIN
 		DECLARE @LogID BIGINT;
 		DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 		DECLARE @RowCount INT;
 
-		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 		VALUES ('Load_PassengerTicket_TransactionalFact', 'PassengerTicket_TransactionalFact', 'Procedure started for date: ' + CONVERT(varchar, @CurrentDate, 101), @StartTime, 'Running');
-		
+
 		SET @LogID = SCOPE_IDENTITY();
 
-BEGIN TRY			
+BEGIN TRY
 			INSERT INTO [DW].[Temp_DailyPayments] (PaymentID, ReservationID, BuyerID, RealPrice, TicketPrice, Discount, Tax, PaymentDateTime, TicketHolderPassengerID, FlightDetailID, SeatDetailID)
 			SELECT p.PaymentID, r.ReservationID, p.BuyerID, p.RealPrice, p.TicketPrice, p.Discount, p.Tax, p.PaymentDateTime, r.PassengerID, r.FlightDetailID, r.SeatDetailID
 			FROM [SA].[Payment] p
 			INNER JOIN [SA].[Reservation] r ON p.ReservationID = r.ReservationID
 			WHERE CAST(p.PaymentDateTime AS DATE) = @CurrentDate;
 
-			IF @@ROWCOUNT = 0 
+			IF @@ROWCOUNT = 0
 			BEGIN
 				UPDATE DW.ETL_Log SET ChangeDescription = 'No payment data found for date: ' + CONVERT(varchar, @CurrentDate, 101), RowsAffected = 0, DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), Status = 'Success' WHERE LogID = @LogID;
 				SET @CurrentDate = DATEADD(day, 1, @CurrentDate);
@@ -59,7 +59,7 @@ BEGIN TRY
 			SELECT dp.PaymentID, fd.DepartureDateTime, fd.FlightDetailID, ac.AircraftID, ac.AirlineID, fd.DepartureAirportID, fd.DestinationAirportID, tc.BaseCost,
 			CASE WHEN ISNULL(fd.FlightCapacity, 0) > 0 THEN ISNULL(fd.TotalCost, 0) / fd.FlightCapacity ELSE 0 END,
 			fd.DistanceKM,
-                      tc.TravelClassID 
+                      tc.TravelClassID
 			FROM [DW].[Temp_DailyPayments] dp
 			INNER JOIN [SA].[FlightDetail] fd ON dp.FlightDetailID = fd.FlightDetailID
 			INNER JOIN [SA].[Aircraft] ac ON fd.AircraftID = ac.AircraftID
@@ -71,15 +71,15 @@ BEGIN TRY
 				dp.PaymentID,
 				BuyerDim.PersonKey,
 				TicketHolderDim.PersonKey
-			FROM 
+			FROM
 				[DW].[Temp_DailyPayments] dp
 			INNER JOIN [SA].[Passenger] BuyerPassenger ON dp.BuyerID = BuyerPassenger.PassengerID
 			INNER JOIN [DW].[DimPerson] BuyerDim ON BuyerPassenger.PersonID = BuyerDim.PersonID
-				AND dp.PaymentDateTime >= BuyerDim.EffectiveFrom 
+				AND dp.PaymentDateTime >= BuyerDim.EffectiveFrom
 				AND dp.PaymentDateTime < ISNULL(BuyerDim.EffectiveTo, '9999-12-31')
 			INNER JOIN [SA].[Passenger] TicketHolderPassenger ON dp.TicketHolderPassengerID = TicketHolderPassenger.PassengerID
 			INNER JOIN [DW].[DimPerson] TicketHolderDim ON TicketHolderPassenger.PersonID = TicketHolderDim.PersonID
-				AND dp.PaymentDateTime >= TicketHolderDim.EffectiveFrom 
+				AND dp.PaymentDateTime >= TicketHolderDim.EffectiveFrom
 				AND dp.PaymentDateTime < ISNULL(TicketHolderDim.EffectiveTo, '9999-12-31');
 
 			INSERT INTO [DW].[PassengerTicket_TransactionalFact] ([PaymentDateKey], [FlightDateKey], [BuyerPersonKey], [TicketHolderPersonKey], [PaymentKey], [FlightKey], [AircraftKey], [AirlineKey], [SourceAirportKey], [DestinationAirportKey], [TravelClassKey], [TicketRealPrice], [TaxAmount], [DiscountAmount], [TicketPrice], [FlightCost], [FlightClassPrice], [FlightRevenue], [KilometersFlown])
@@ -95,19 +95,19 @@ BEGIN TRY
 				ISNULL(fd.FlightClassPrice, 0),
 				ISNULL(dp.TicketPrice, 0) - ISNULL(fd.FlightCost, 0),
 				ISNULL(fd.KilometersFlown, 0)
-			FROM 
+			FROM
 				[DW].[Temp_DailyPayments] dp
-			INNER JOIN 
+			INNER JOIN
 				[DW].[Temp_EnrichedFlightData] fd ON dp.PaymentID = fd.PaymentID
-			INNER JOIN 
+			INNER JOIN
 				[DW].[Temp_EnrichedPersonData] pd ON dp.PaymentID = pd.PaymentID;
-						
+
 			SET @RowCount = @@ROWCOUNT;
 
 			TRUNCATE TABLE [DW].[Temp_DailyPayments];
 			TRUNCATE TABLE [DW].[Temp_EnrichedFlightData];
 			TRUNCATE TABLE [DW].[Temp_EnrichedPersonData];
-			
+
 			UPDATE DW.ETL_Log SET ChangeDescription = 'Load complete for date: ' + CONVERT(varchar, @CurrentDate, 101), RowsAffected = @RowCount, DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), Status = 'Success' WHERE LogID = @LogID;
 
 		END TRY

--- a/Datawarehouse/Facts/RevenueMart/Initial_FlightOperation_Factless.sql
+++ b/Datawarehouse/Facts/RevenueMart/Initial_FlightOperation_Factless.sql
@@ -7,13 +7,13 @@ BEGIN
     DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
     DECLARE @RowCount INT;
 
-    INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+    INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
     VALUES ('Initial_FlightOperation_Factless', 'FlightOperation_Factless', 'Procedure started for initial full load', @StartTime, 'Running');
-        
+
     SET @LogID = SCOPE_IDENTITY();
 
     BEGIN TRY
-        INSERT INTO [DW].[FlightOperation_Factless] (   -- <-- Fixed table name here!
+        INSERT INTO [DW].[FlightOperation_Factless] (
             FlightKey,
             SourceAirportKey,
             DestinationAirportKey,
@@ -28,9 +28,9 @@ BEGIN
             ac.AirlineID AS AirlineKey,
             fd.AircraftID AS AircraftKey,
             CASE
-                WHEN fo.CancelFlag = 1 THEN 3 -- Canceled
-                WHEN fo.DelayMinutes > 0 THEN 2 -- Delayed
-                ELSE 1 -- On-Time
+                WHEN fo.CancelFlag = 1 THEN 3
+                WHEN fo.DelayMinutes > 0 THEN 2
+                ELSE 1
             END AS OperationTypeKey
         FROM
             [SA].[FlightOperation] fo

--- a/Datawarehouse/Facts/RevenueMart/Initial_PassengerActivity_ACCFact.sql
+++ b/Datawarehouse/Facts/RevenueMart/Initial_PassengerActivity_ACCFact.sql
@@ -7,9 +7,9 @@ BEGIN
     DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
     DECLARE @RowCount INT;
 
-    INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+    INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
     VALUES ('Initial_PassengerActivity_ACCFact', 'PassengerActivity_ACCFact', 'Procedure started for initial full load', @StartTime, 'Running');
-        
+
     SET @LogID = SCOPE_IDENTITY();
 
     BEGIN TRY
@@ -17,21 +17,21 @@ BEGIN
         TRUNCATE TABLE [DW].[Temp_LifetimeSourceData];
 
         WITH LifetimeSummableAggregates AS (
-            SELECT 
-                PersonKey, 
-                SUM(YearlyFlights) AS TotalFlights, 
-                SUM(YearlyTicketValue) AS TotalAmountPaid, 
-                SUM(YearlyMilesFlown) AS TotalMilesFlown, 
-                SUM(YearlyDiscountAmount) AS TotalDiscountAmount, 
-                MAX(YearlyMaxFlightDistance) AS MaxFlightDistance, 
+            SELECT
+                PersonKey,
+                SUM(YearlyFlights) AS TotalFlights,
+                SUM(YearlyTicketValue) AS TotalAmountPaid,
+                SUM(YearlyMilesFlown) AS TotalMilesFlown,
+                SUM(YearlyDiscountAmount) AS TotalDiscountAmount,
+                MAX(YearlyMaxFlightDistance) AS MaxFlightDistance,
                 MIN(YearlyMinFlightDistance) AS MinFlightDistance
             FROM [DW].[PassengerActivity_YearlyFact]
             GROUP BY PersonKey
         ),
         LifetimeDistinctAggregates AS (
-            SELECT 
-                current_person.PersonKey, 
-                COUNT(DISTINCT fptt.AirlineKey) AS DistinctAirlinesUsed, 
+            SELECT
+                current_person.PersonKey,
+                COUNT(DISTINCT fptt.AirlineKey) AS DistinctAirlinesUsed,
                 COUNT(DISTINCT CONCAT(fptt.SourceAirportKey, '-', fptt.DestinationAirportKey)) AS DistinctRoutesFlown
             FROM [DW].[PassengerTicket_TransactionalFact] fptt
             INNER JOIN [DW].[DimPayment] dp ON fptt.PaymentKey = dp.PaymentKey
@@ -46,36 +46,36 @@ BEGIN
             TotalFlights, MaxFlightDistance, MinFlightDistance
         )
         SELECT
-            sa.PersonKey, 
-            sa.TotalFlights AS TotalTicketValue, 
-            sa.TotalAmountPaid, 
+            sa.PersonKey,
+            sa.TotalFlights AS TotalTicketValue,
+            sa.TotalAmountPaid,
             sa.TotalMilesFlown,
-            sa.TotalDiscountAmount, 
+            sa.TotalDiscountAmount,
             CASE WHEN sa.TotalFlights > 0 THEN sa.TotalAmountPaid / sa.TotalFlights ELSE 0 END,
-            da.DistinctAirlinesUsed, 
-            da.DistinctRoutesFlown, 
-            sa.TotalFlights, 
-            sa.MaxFlightDistance, 
+            da.DistinctAirlinesUsed,
+            da.DistinctRoutesFlown,
+            sa.TotalFlights,
+            sa.MaxFlightDistance,
             sa.MinFlightDistance
         FROM LifetimeSummableAggregates sa
         LEFT JOIN LifetimeDistinctAggregates da ON sa.PersonKey = da.PersonKey;
 
         SET @RowCount = @@ROWCOUNT;
-        UPDATE DW.ETL_Log 
-            SET ChangeDescription = 'Initial full load complete', 
-                RowsAffected = @RowCount, 
-                DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), 
-                Status = 'Success' 
+        UPDATE DW.ETL_Log
+            SET ChangeDescription = 'Initial full load complete',
+                RowsAffected = @RowCount,
+                DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()),
+                Status = 'Success'
         WHERE LogID = @LogID;
 
     END TRY
     BEGIN CATCH
         DECLARE @ErrMsg NVARCHAR(MAX) = ERROR_MESSAGE();
-        UPDATE DW.ETL_Log 
-            SET ChangeDescription = 'Initial full load failed', 
-                DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), 
-                Status = 'Error', 
-                Message = @ErrMsg 
+        UPDATE DW.ETL_Log
+            SET ChangeDescription = 'Initial full load failed',
+                DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()),
+                Status = 'Error',
+                Message = @ErrMsg
         WHERE LogID = @LogID;
         THROW;
     END CATCH

--- a/Datawarehouse/Facts/RevenueMart/Initial_PassengerTicket_TransactionalFact.sql
+++ b/Datawarehouse/Facts/RevenueMart/Initial_PassengerTicket_TransactionalFact.sql
@@ -6,10 +6,10 @@ BEGIN
 	DECLARE @StartDate date;
 	DECLARE @EndDate date;
 
-	SELECT 
+	SELECT
 		@StartDate = MIN(CAST(PaymentDateTime AS DATE)),
 		@EndDate = MAX(CAST(PaymentDateTime AS DATE))
-	FROM 
+	FROM
 		[SA].[Payment];
 
 	IF @StartDate IS NULL
@@ -19,26 +19,26 @@ BEGIN
 	END
 
 	DECLARE @CurrentDate date = @StartDate;
-	
+
 	WHILE @CurrentDate <= @EndDate
 	BEGIN
 		DECLARE @LogID BIGINT;
 		DECLARE @StartTime DATETIME2(3) = SYSUTCDATETIME();
 		DECLARE @RowCount INT;
 
-		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status) 
+		INSERT INTO DW.ETL_Log (ProcedureName, TargetTable, ChangeDescription, ActionTime, Status)
 		VALUES ('Initial_PassengerTicket_TransactionalFact', 'PassengerTicket_TransactionalFact', 'Procedure started for date: ' + CONVERT(varchar, @CurrentDate, 101), @StartTime, 'Running');
-		
+
 		SET @LogID = SCOPE_IDENTITY();
 
-		BEGIN TRY			
+		BEGIN TRY
 			INSERT INTO [DW].[Temp_DailyPayments] (PaymentID, ReservationID, BuyerID, RealPrice, TicketPrice, Discount, Tax, PaymentDateTime, TicketHolderPassengerID, FlightDetailID, SeatDetailID)
 			SELECT p.PaymentID, r.ReservationID, p.BuyerID, p.RealPrice, p.TicketPrice, p.Discount, p.Tax, p.PaymentDateTime, r.PassengerID, r.FlightDetailID, r.SeatDetailID
 			FROM [SA].[Payment] p
 			INNER JOIN [SA].[Reservation] r ON p.ReservationID = r.ReservationID
 			WHERE CAST(p.PaymentDateTime AS DATE) = @CurrentDate;
 
-			IF @@ROWCOUNT = 0 
+			IF @@ROWCOUNT = 0
 			BEGIN
 				UPDATE DW.ETL_Log SET ChangeDescription = 'No payment data found for date: ' + CONVERT(varchar, @CurrentDate, 101), RowsAffected = 0, DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), Status = 'Success' WHERE LogID = @LogID;
 				SET @CurrentDate = DATEADD(day, 1, @CurrentDate);
@@ -49,27 +49,27 @@ BEGIN
 			SELECT dp.PaymentID, fd.DepartureDateTime, fd.FlightDetailID, ac.AircraftID, ac.AirlineID, fd.DepartureAirportID, fd.DestinationAirportID, tc.BaseCost,
 			CASE WHEN ISNULL(fd.FlightCapacity, 0) > 0 THEN ISNULL(fd.TotalCost, 0) / fd.FlightCapacity ELSE 0 END,
 			fd.DistanceKM,
-                      tc.TravelClassID 
+                      tc.TravelClassID
 			FROM [DW].[Temp_DailyPayments] dp
 			INNER JOIN [SA].[FlightDetail] fd ON dp.FlightDetailID = fd.FlightDetailID
 			INNER JOIN [SA].[Aircraft] ac ON fd.AircraftID = ac.AircraftID
 			INNER JOIN [SA].[SeatDetail] sd ON dp.SeatDetailID = sd.SeatDetailID
 			INNER JOIN [SA].[TravelClass] tc ON sd.TravelClassID = tc.TravelClassID;
-			
+
 			INSERT INTO [DW].[Temp_EnrichedPersonData] (PaymentID, BuyerPersonKey, TicketHolderPersonKey)
 			SELECT
 				dp.PaymentID,
 				BuyerDim.PersonKey,
 				TicketHolderDim.PersonKey
-			FROM 
+			FROM
 				[DW].[Temp_DailyPayments] dp
 			INNER JOIN [SA].[Passenger] BuyerPassenger ON dp.BuyerID = BuyerPassenger.PassengerID
 			INNER JOIN [DW].[DimPerson] BuyerDim ON BuyerPassenger.PersonID = BuyerDim.PersonID
-				AND dp.PaymentDateTime >= BuyerDim.EffectiveFrom 
+				AND dp.PaymentDateTime >= BuyerDim.EffectiveFrom
 				AND dp.PaymentDateTime < ISNULL(BuyerDim.EffectiveTo, '9999-12-31')
 			INNER JOIN [SA].[Passenger] TicketHolderPassenger ON dp.TicketHolderPassengerID = TicketHolderPassenger.PassengerID
 			INNER JOIN [DW].[DimPerson] TicketHolderDim ON TicketHolderPassenger.PersonID = TicketHolderDim.PersonID
-				AND dp.PaymentDateTime >= TicketHolderDim.EffectiveFrom 
+				AND dp.PaymentDateTime >= TicketHolderDim.EffectiveFrom
 				AND dp.PaymentDateTime < ISNULL(TicketHolderDim.EffectiveTo, '9999-12-31');
 
 			INSERT INTO [DW].[PassengerTicket_TransactionalFact] ([PaymentDateKey], [FlightDateKey], [BuyerPersonKey], [TicketHolderPersonKey], [PaymentKey], [FlightKey], [AircraftKey], [AirlineKey], [SourceAirportKey], [DestinationAirportKey], [TravelClassKey], [TicketRealPrice], [TaxAmount], [DiscountAmount], [TicketPrice], [FlightCost], [FlightClassPrice], [FlightRevenue], [KilometersFlown])
@@ -85,19 +85,19 @@ BEGIN
 				ISNULL(fd.FlightClassPrice, 0),
 				ISNULL(dp.TicketPrice, 0) - ISNULL(fd.FlightCost, 0),
 				ISNULL(fd.KilometersFlown, 0)
-			FROM 
+			FROM
 				[DW].[Temp_DailyPayments] dp
-			INNER JOIN 
+			INNER JOIN
 				[DW].[Temp_EnrichedFlightData] fd ON dp.PaymentID = fd.PaymentID
-			INNER JOIN 
+			INNER JOIN
 				[DW].[Temp_EnrichedPersonData] pd ON dp.PaymentID = pd.PaymentID;
-			
+
 			SET @RowCount = @@ROWCOUNT;
 
 			TRUNCATE TABLE [DW].[Temp_DailyPayments];
 			TRUNCATE TABLE [DW].[Temp_EnrichedFlightData];
 			TRUNCATE TABLE [DW].[Temp_EnrichedPersonData];
-			
+
 			UPDATE DW.ETL_Log SET ChangeDescription = 'Load complete for date: ' + CONVERT(varchar, @CurrentDate, 101), RowsAffected = @RowCount, DurationSec = DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), Status = 'Success' WHERE LogID = @LogID;
 
 		END TRY

--- a/Source/Create_Source_all.sql
+++ b/Source/Create_Source_all.sql
@@ -131,7 +131,7 @@ CREATE TABLE [Source].[LoyaltyTransactionType] (
 )
 GO
 
--- Maintenance Data Mart
+
 CREATE TABLE [Source].[MaintenanceLocation] (
   [LocationID]   nvarchar(100) PRIMARY KEY,
   [Name]          nvarchar(100),
@@ -141,7 +141,7 @@ CREATE TABLE [Source].[MaintenanceLocation] (
 );
 GO
 
--- Maintenance Data Mart
+
 CREATE TABLE [Source].[MaintenanceType] (
   [MaintenanceTypeID]  integer PRIMARY KEY,
   [Name]               nvarchar(100),
@@ -150,7 +150,7 @@ CREATE TABLE [Source].[MaintenanceType] (
 );
 GO
 
--- Maintenance Data Mart
+
 CREATE TABLE [Source].[Part] (
   [PartID]                     integer PRIMARY KEY,
   [Name]                   nvarchar(100),
@@ -265,11 +265,11 @@ CREATE TABLE [Source].[ServiceOfferingItem] (
 )
 GO
 
--- Maintenance Data Mart
+
 CREATE TABLE [Source].[Technician] (
     [TechnicianID] INT PRIMARY KEY,
-    [PersonID] INT,                   
-    [Specialty] NVARCHAR(100),        
+    [PersonID] INT,
+    [Specialty] NVARCHAR(100),
 );
 GO
 
@@ -281,7 +281,7 @@ CREATE TABLE [Source].[TravelClass] (
 )
 GO
 
--- Maintenance Data Mart
+
 CREATE TABLE [Source].[MaintenanceEvent] (
   MaintenanceEventID INT PRIMARY KEY,
   AircraftID INT NOT NULL,
@@ -299,7 +299,7 @@ CREATE TABLE [Source].[MaintenanceEvent] (
 );
 GO
 
--- Maintenance Data Mart
+
 CREATE TABLE [Source].[PartReplacement] (
   PartReplacementID INT PRIMARY KEY,
   AircraftID INT NOT NULL,

--- a/Source/Sample_Source_all.sql
+++ b/Source/Sample_Source_all.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO Source.Airline 
+INSERT INTO Source.Airline
   (AirlineID, Name, Country, FoundedDate, HeadquartersNumber, FleetSize, Website, Current_IATA_Code) VALUES
 (1, 'Emirates',           'UAE',       '1985-03-25', '+97143179999', 269, 'www.emirates.com',       'EK'),
 (2, 'Lufthansa',          'Germany',   '1953-01-06', '+496922960',   316, 'www.lufthansa.com',      'LH'),

--- a/Staging Area/ALL_ETL.sql
+++ b/Staging Area/ALL_ETL.sql
@@ -3,7 +3,7 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
-    -- List of all expected ETL procedures in SA schema
+
     DECLARE @procs TABLE (ProcName NVARCHAR(128));
     INSERT INTO @procs (ProcName) VALUES
         (N'ETL_Account'),

--- a/Staging Area/Create_Log_Table.sql
+++ b/Staging Area/Create_Log_Table.sql
@@ -1,13 +1,13 @@
 CREATE TABLE [SA].[ETL_Log] (
     [LogID]             BIGINT            IDENTITY(1,1) NOT NULL PRIMARY KEY,
-    [ProcedureName]     NVARCHAR(255)     NOT NULL,    -- e.g. 'ETL_FlightOperation'
-    [SourceTable]       NVARCHAR(255)     NOT NULL,    -- e.g. 'Source.FlightOperation'
-    [TargetTable]       NVARCHAR(255)     NOT NULL,    -- e.g. 'SA.FlightOperation'
-    [ChangeDescription] NVARCHAR(MAX)     NULL,        -- free-form description of what happened
-    [RowsAffected]      INT               NULL,        -- number of rows inserted/updated/deleted
+    [ProcedureName]     NVARCHAR(255)     NOT NULL,
+    [SourceTable]       NVARCHAR(255)     NOT NULL,
+    [TargetTable]       NVARCHAR(255)     NOT NULL,
+    [ChangeDescription] NVARCHAR(MAX)     NULL,
+    [RowsAffected]      INT               NULL,
     [ActionTime]        DATETIME2(3)      NOT NULL DEFAULT SYSUTCDATETIME(),
-    [DurationSec]       DECIMAL(9,3)      NULL,        -- elapsed time in seconds
-    [Status]            NVARCHAR(50)      NULL,        -- e.g. 'Started','Success','Error'
-    [Message]           NVARCHAR(MAX)     NULL         -- error or informational message
+    [DurationSec]       DECIMAL(9,3)      NULL,
+    [Status]            NVARCHAR(50)      NULL,
+    [Message]           NVARCHAR(MAX)     NULL
 );
 GO

--- a/Staging Area/Create_SA_all.sql
+++ b/Staging Area/Create_SA_all.sql
@@ -1,7 +1,7 @@
 CREATE SCHEMA [SA]
 GO
 
--- Account
+
 CREATE TABLE [SA].[Account] (
   [AccountID] integer PRIMARY KEY,
   [PassengerID] integer NOT NULL,
@@ -13,7 +13,7 @@ CREATE TABLE [SA].[Account] (
 )
 GO
 
--- AccountTierHistory
+
 CREATE TABLE [SA].[AccountTierHistory] (
   [HistoryID] integer PRIMARY KEY,
   [AccountID] integer NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE [SA].[AccountTierHistory] (
 )
 GO
 
--- Aircraft
+
 CREATE TABLE [SA].[Aircraft] (
   [AircraftID] integer PRIMARY KEY,
   [Model] nvarchar(50),
@@ -42,7 +42,7 @@ CREATE TABLE [SA].[Aircraft] (
 )
 GO
 
--- Airline
+
 CREATE TABLE [SA].[Airline] (
   [AirlineID] integer PRIMARY KEY,
   [Name] nvarchar(100),
@@ -58,7 +58,7 @@ CREATE TABLE [SA].[Airline] (
 )
 GO
 
--- AirlineAirportService
+
 CREATE TABLE [SA].[AirlineAirportService] (
   [ServiceTypeCode] nvarchar(50) NOT NULL,
   [FlightTypeCode] nvarchar(50) NOT NULL,
@@ -75,7 +75,7 @@ CREATE TABLE [SA].[AirlineAirportService] (
 )
 GO
 
--- Airport
+
 CREATE TABLE [SA].[Airport] (
   [AirportID] integer PRIMARY KEY,
   [City] nvarchar(50),
@@ -94,7 +94,7 @@ CREATE TABLE [SA].[Airport] (
 )
 GO
 
--- CrewAssignment
+
 CREATE TABLE [SA].[CrewAssignment] (
   [CrewAssignmentID] integer PRIMARY KEY,
   [FlightDetailID] integer NOT NULL,
@@ -105,7 +105,7 @@ CREATE TABLE [SA].[CrewAssignment] (
 )
 GO
 
--- CrewMember
+
 CREATE TABLE [SA].[CrewMember] (
   [CrewMemberID] integer PRIMARY KEY,
   [PersonID] integer NOT NULL,
@@ -116,7 +116,7 @@ CREATE TABLE [SA].[CrewMember] (
 )
 GO
 
--- FlightDetail
+
 CREATE TABLE [SA].[FlightDetail] (
   [FlightDetailID] integer PRIMARY KEY,
   [DepartureAirportID] integer NOT NULL,
@@ -133,7 +133,7 @@ CREATE TABLE [SA].[FlightDetail] (
 )
 GO
 
--- FlightOperation
+
 CREATE TABLE [SA].[FlightOperation] (
   [FlightOperationID] integer PRIMARY KEY,
   [FlightDetailID] integer NOT NULL,
@@ -149,7 +149,7 @@ CREATE TABLE [SA].[FlightOperation] (
 )
 GO
 
--- Item
+
 CREATE TABLE [SA].[Item] (
   [ItemID] INT PRIMARY KEY,
   [ItemName] NVARCHAR(100),
@@ -162,7 +162,7 @@ CREATE TABLE [SA].[Item] (
 )
 GO
 
--- LoyaltyTier
+
 CREATE TABLE [SA].[LoyaltyTier] (
   [LoyaltyTierID] integer PRIMARY KEY,
   [Name] nvarchar(50) NOT NULL,
@@ -174,7 +174,7 @@ CREATE TABLE [SA].[LoyaltyTier] (
 )
 GO
 
--- LoyaltyTransactionType
+
 CREATE TABLE [SA].[LoyaltyTransactionType] (
   [LoyaltyTransactionTypeID] INT PRIMARY KEY,
   [TypeName] NVARCHAR(50),
@@ -184,7 +184,7 @@ CREATE TABLE [SA].[LoyaltyTransactionType] (
 )
 GO
 
--- MaintenanceLocation
+
 CREATE TABLE [SA].[MaintenanceLocation] (
   [LocationID] nvarchar(100) PRIMARY KEY,
   [Name] nvarchar(100),
@@ -197,7 +197,7 @@ CREATE TABLE [SA].[MaintenanceLocation] (
 )
 GO
 
--- MaintenanceType
+
 CREATE TABLE [SA].[MaintenanceType] (
   [MaintenanceTypeID] integer PRIMARY KEY,
   [Name] nvarchar(100),
@@ -209,7 +209,7 @@ CREATE TABLE [SA].[MaintenanceType] (
 )
 GO
 
--- Part
+
 CREATE TABLE [SA].[Part] (
   [PartID] integer PRIMARY KEY,
   [Name] nvarchar(100),
@@ -223,7 +223,7 @@ CREATE TABLE [SA].[Part] (
 )
 GO
 
--- Passenger
+
 CREATE TABLE [SA].[Passenger] (
   [PassengerID] integer PRIMARY KEY,
   [PersonID] integer NOT NULL,
@@ -234,7 +234,7 @@ CREATE TABLE [SA].[Passenger] (
 )
 GO
 
--- Payment
+
 CREATE TABLE [SA].[Payment] (
   [PaymentID] integer PRIMARY KEY,
   [ReservationID] integer NOT NULL,
@@ -252,7 +252,7 @@ CREATE TABLE [SA].[Payment] (
 )
 GO
 
--- Person
+
 CREATE TABLE [SA].[Person] (
   [PersonID] integer PRIMARY KEY,
   [NatCode] nvarchar(20) NOT NULL,
@@ -271,7 +271,7 @@ CREATE TABLE [SA].[Person] (
 )
 GO
 
--- PointConversionRate
+
 CREATE TABLE [SA].[PointConversionRate] (
   [PointConversionRateID] INT PRIMARY KEY,
   [ConversionRate] DECIMAL(18,6) NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE [SA].[PointConversionRate] (
 )
 GO
 
--- Points
+
 CREATE TABLE [SA].[Points] (
   [PointsID] integer PRIMARY KEY,
   [AccountID] integer NOT NULL,
@@ -294,7 +294,7 @@ CREATE TABLE [SA].[Points] (
 )
 GO
 
--- PointsTransaction
+
 CREATE TABLE [SA].[PointsTransaction] (
   [PointsTransactionID] INT PRIMARY KEY,
   [AccountID] INT NOT NULL,
@@ -314,7 +314,7 @@ CREATE TABLE [SA].[PointsTransaction] (
 )
 GO
 
--- Reservation
+
 CREATE TABLE [SA].[Reservation] (
   [ReservationID] integer PRIMARY KEY,
   [PassengerID] integer NOT NULL,
@@ -328,7 +328,7 @@ CREATE TABLE [SA].[Reservation] (
 )
 GO
 
--- SeatDetail
+
 CREATE TABLE [SA].[SeatDetail] (
   [SeatDetailID] integer PRIMARY KEY,
   [AircraftID] integer NOT NULL,
@@ -342,7 +342,7 @@ CREATE TABLE [SA].[SeatDetail] (
 )
 GO
 
--- ServiceOffering
+
 CREATE TABLE [SA].[ServiceOffering] (
   [ServiceOfferingID] INT PRIMARY KEY,
   [TravelClassID] INT,
@@ -356,7 +356,7 @@ CREATE TABLE [SA].[ServiceOffering] (
 
 GO
 
--- ServiceOfferingItem
+
 CREATE TABLE [SA].[ServiceOfferingItem] (
   [ServiceOfferingID] INT NOT NULL,
   [ItemID] INT NOT NULL,
@@ -369,7 +369,7 @@ CREATE TABLE [SA].[ServiceOfferingItem] (
 
 GO
 
--- Technician
+
 CREATE TABLE [SA].[Technician] (
   [TechnicianID] INT PRIMARY KEY,
   [PersonID] INT,
@@ -380,7 +380,7 @@ CREATE TABLE [SA].[Technician] (
 )
 GO
 
--- TravelClass
+
 CREATE TABLE [SA].[TravelClass] (
   [TravelClassID] INT PRIMARY KEY,
   [ClassName] NVARCHAR(50),
@@ -393,7 +393,7 @@ CREATE TABLE [SA].[TravelClass] (
 
 GO
 
--- MaintenanceEvent
+
 CREATE TABLE [SA].[MaintenanceEvent] (
   [MaintenanceEventID] INT PRIMARY KEY,
   [AircraftID] INT NOT NULL,
@@ -415,7 +415,7 @@ CREATE TABLE [SA].[MaintenanceEvent] (
 GO
 
 
--- PartReplacement
+
 CREATE TABLE [SA].[PartReplacement] (
   [PartReplacementID] INT PRIMARY KEY,
   [AircraftID] INT NOT NULL,

--- a/Staging Area/Drop_SA_all.sql
+++ b/Staging Area/Drop_SA_all.sql
@@ -29,10 +29,10 @@ DROP TABLE IF EXISTS [SA].[ServiceOfferingItem];
 DROP TABLE IF EXISTS [SA].[Technician];
 DROP TABLE IF EXISTS [SA].[TravelClass];
 
--- Drop ETL Log table
+
 DROP TABLE IF EXISTS [SA].[ETL_Log];
 
--- Drop all ETL procedures in alphabetical order
+
 IF OBJECT_ID('[SA].[ETL_Account]', 'P') IS NOT NULL DROP PROCEDURE [SA].[ETL_Account];
 IF OBJECT_ID('[SA].[ETL_AccountTierHistory]', 'P') IS NOT NULL DROP PROCEDURE [SA].[ETL_AccountTierHistory];
 IF OBJECT_ID('[SA].[ETL_Aircraft]', 'P') IS NOT NULL DROP PROCEDURE [SA].[ETL_Aircraft];
@@ -65,7 +65,7 @@ IF OBJECT_ID('[SA].[ETL_ServiceOfferingItem]', 'P') IS NOT NULL DROP PROCEDURE [
 IF OBJECT_ID('[SA].[ETL_Technician]', 'P') IS NOT NULL DROP PROCEDURE [SA].[ETL_Technician];
 IF OBJECT_ID('[SA].[ETL_TravelClass]', 'P') IS NOT NULL DROP PROCEDURE [SA].[ETL_TravelClass];
 
--- Drop the main ETL procedure
+
 IF OBJECT_ID('[SA].[Main_ETL]', 'P') IS NOT NULL DROP PROCEDURE [SA].[Main_ETL];
 
 DROP SCHEMA IF EXISTS [SA];

--- a/Staging Area/ETL_Airline.sql
+++ b/Staging Area/ETL_Airline.sql
@@ -31,7 +31,7 @@ BEGIN
           ON TARGET.AirlineID = SOURCE.AirlineID
 
         WHEN MATCHED AND EXISTS (
-            SELECT 
+            SELECT
                 SOURCE.Name,
                 SOURCE.Country,
                 SOURCE.FoundedDate,
@@ -40,7 +40,7 @@ BEGIN
                 SOURCE.Website,
                 SOURCE.Current_IATA_Code
             EXCEPT
-            SELECT 
+            SELECT
                 TARGET.Name,
                 TARGET.Country,
                 TARGET.FoundedDate,

--- a/Staging Area/ETL_FlightOperation.sql
+++ b/Staging Area/ETL_FlightOperation.sql
@@ -8,7 +8,7 @@ BEGIN
         @RowsAffected  INT,
         @LogID         BIGINT;
 
-    -- 1) Assume fatal: insert initial log entry
+
     INSERT INTO [SA].[ETL_Log] (
         ProcedureName,
         SourceTable,

--- a/Staging Area/ETL_Part.sql
+++ b/Staging Area/ETL_Part.sql
@@ -31,14 +31,14 @@ BEGIN
           ON TARGET.PartID = SOURCE.PartID
 
         WHEN MATCHED AND EXISTS (
-            SELECT 
+            SELECT
                 SOURCE.Name,
                 SOURCE.PartNumber,
                 SOURCE.Manufacturer,
                 SOURCE.WarrantyPeriodMonths,
                 SOURCE.Category
             EXCEPT
-            SELECT 
+            SELECT
                 TARGET.Name,
                 TARGET.PartNumber,
                 TARGET.Manufacturer,

--- a/Staging Area/ETL_Technician.sql
+++ b/Staging Area/ETL_Technician.sql
@@ -31,11 +31,11 @@ BEGIN
           ON TARGET.TechnicianID = SOURCE.TechnicianID
 
         WHEN MATCHED AND EXISTS (
-            SELECT 
+            SELECT
                 SOURCE.PersonID,
                 SOURCE.Specialty
             EXCEPT
-            SELECT 
+            SELECT
                 TARGET.PersonID,
                 TARGET.Specialty
         ) THEN


### PR DESCRIPTION
## Summary
- strip comments from SQL definitions and ETL scripts

## Testing
- `python3 Test Scripts/Test_PersonDim_SCD2.py` *(fails: Can't open lib 'ODBC Driver 18 for SQL Server')*
- `python3 Test Scripts/Test_LoyaltyTierDim_SCD2.py` *(fails: Can't open lib 'ODBC Driver 18 for SQL Server')*

------
https://chatgpt.com/codex/tasks/task_e_6860986d1320833084e17fd0518b1db4